### PR TITLE
Upgrade config file from version 3-alpha to version 3

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -4,11 +4,19 @@ multigroup: true
 projectName: falcon-operator
 repo: github.com/crowdstrike/falcon-operator
 resources:
-- crdVersion: v1
+- api:
+    crdVersion: v1
+    # TODO(user): Uncomment the below line if this resource's CRD is namespace scoped, else delete it.
+    # namespaced: true
+  # TODO(user): Uncomment the below line if this resource implements a controller, else delete it.
+  # controller: true
+  domain: crowdstrike.com
   group: falcon
   kind: FalconConfig
+  # TODO(user): Update the package path for your API if the below value is incorrect.
+  path: github.com/crowdstrike/falcon-operator/apis/falcon/v1alpha1
   version: v1alpha1
-version: 3-alpha
+version: "3"
 plugins:
   manifests.sdk.operatorframework.io/v2: {}
   scorecard.sdk.operatorframework.io/v2: {}


### PR DESCRIPTION
Addressing:
```
WARN[0000] Config version 3-alpha has been stabilized as 3, and 3-alpha is no longer supported. Run `operator-sdk alpha config-3alpha-to-3` to upgrade your PROJECT config file to version 3
Error: error reading configuration: version 3-alpha is not supported
```