### PR TITLE
Do not hard-code securityContext

### DIFF
--- a/bundle/manifests/falcon-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/falcon-operator.clusterserviceversion.yaml
@@ -131,8 +131,6 @@ spec:
                     memory: 20Mi
                 securityContext:
                   allowPrivilegeEscalation: false
-              securityContext:
-                runAsUser: 65532
               terminationGracePeriodSeconds: 10
       permissions:
       - rules:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -22,8 +22,6 @@ spec:
       labels:
         control-plane: controller-manager
     spec:
-      securityContext:
-        runAsUser: 65532
       containers:
       - command:
         - /manager


### PR DESCRIPTION
Some clusters may have random runAsUser assignments and hence our hard-coded value may not always match with the on-cluster settings.