### PR TITLE
Improve error message on EKS misconfiguration

### DIFF
--- a/pkg/aws/session.go
+++ b/pkg/aws/session.go
@@ -2,6 +2,8 @@ package aws
 
 import (
 	"context"
+	"fmt"
+	"os"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -14,6 +16,10 @@ type Config struct {
 }
 
 func NewConfig() (*Config, error) {
+	if os.Getenv("AWS_REGION") == "" {
+		return nil, fmt.Errorf("Environment variable AWS_REGION is not set for the operator. This is indicator of misconfiguration. Please ensure kubernetes service account bound to the operator is configured by eksctl create iamserviceaccount as described in the documentation.")
+	}
+
 	cfg, err := config.LoadDefaultConfig(context.TODO())
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Previous error message was not instructive enough.
```
2021-09-23T13:20:23.496Z        ERROR controller-runtime.manager.controller.falconcontainer   Reconciler error
{"reconciler group": "falcon.crowdstrike.com", "reconciler kind": "FalconContainer", "name": "my-setup", "namespace": "", "error": "Failed to create ECR repository: Failed to upsert ECR repository: Could not create ECR repository falcon-container: operation error ECR: CreateRepository, failed to resolve service endpoint, an AWS region is required, but was not found"}
```