### PR TITLE
Ensure falcon-operator has access to IAM token provided by AWS OIDC

### DIFF
--- a/deploy/falcon-operator.yaml
+++ b/deploy/falcon-operator.yaml
@@ -503,6 +503,8 @@ spec:
       labels:
         control-plane: falcon-operator-controller-manager
     spec:
+      securityContext:
+        fsGroup: 65534
       containers:
       - args:
         - --leader-elect

--- a/deploy/parts/operator.yaml
+++ b/deploy/parts/operator.yaml
@@ -34,6 +34,8 @@ spec:
       labels:
         control-plane: falcon-operator-controller-manager
     spec:
+      securityContext:
+        fsGroup: 65534
       containers:
       - args:
         - --leader-elect


### PR DESCRIPTION
Addressing:
```
unable to read file at /var/run/secrets/eks.amazonaws.com/serviceaccount/token caused by: open /var/run/secrets/eks.amazonaws.com/serviceaccount/token: permission denied"
```
