### PR TITLE
Provide minimal kube version required in CSV

### DIFF
--- a/bundle/manifests/falcon-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/falcon-operator.clusterserviceversion.yaml
@@ -447,6 +447,7 @@ spec:
   - name: Falcon Operator
     url: https://github.com/CrowdStrike/falcon-operator
   maturity: alpha
+  minKubeVersion: 1.17.0
   provider:
     name: CrowdStrike
     url: https://crowdStrike.com

--- a/config/manifests/bases/falcon-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/falcon-operator.clusterserviceversion.yaml
@@ -186,6 +186,7 @@ spec:
   - name: Falcon Operator
     url: https://github.com/CrowdStrike/falcon-operator
   maturity: alpha
+  minKubeVersion: 1.17.0
   provider:
     name: CrowdStrike
     url: https://crowdStrike.com


### PR DESCRIPTION
Addressing:
```
WARN[0001] Warning: Value : (falcon-operator.v0.3.0) csv.Spec.minKubeVersion is not informed. It is recommended you provide this information. Otherwise, it would mean that your operator project can be distributed and installed in any cluster version available, which is not necessarily the case for all projects.
```