### PR TITLE
Add deamonset permissions to the operator deployed by falcon-operator

### DIFF
--- a/deploy/falcon-operator.yaml
+++ b/deploy/falcon-operator.yaml
@@ -450,6 +450,18 @@ rules:
 - apiGroups:
   - apps
   resources:
+  - daemonsets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
   - deployments
   verbs:
   - create
@@ -463,6 +475,27 @@ rules:
   - delete
   - get
   - list
+  - update
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - list
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
   - update
   - watch
 - apiGroups:
@@ -543,26 +576,13 @@ rules:
   - create
   - delete
 - apiGroups:
-  - ""
-  - coordination.k8s.io
+  - security.openshift.io
+  resourceNames:
+  - privileged
   resources:
-  - configmaps
-  - leases
+  - securitycontextconstraints
   verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - ""
-  resources:
-  - events
-  verbs:
-  - create
-  - patch
+  - use
 - apiGroups:
   - ""
   resources:
@@ -571,6 +591,13 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/deploy/parts/role.yaml
+++ b/deploy/parts/role.yaml
@@ -54,6 +54,18 @@ rules:
 - apiGroups:
   - apps
   resources:
+  - daemonsets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
   - deployments
   verbs:
   - create
@@ -67,6 +79,27 @@ rules:
   - delete
   - get
   - list
+  - update
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - list
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
   - update
   - watch
 - apiGroups:
@@ -147,26 +180,13 @@ rules:
   - create
   - delete
 - apiGroups:
-  - ""
-  - coordination.k8s.io
+  - security.openshift.io
+  resourceNames:
+  - privileged
   resources:
-  - configmaps
-  - leases
+  - securitycontextconstraints
   verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - ""
-  resources:
-  - events
-  verbs:
-  - create
-  - patch
+  - use
 - apiGroups:
   - ""
   resources:
@@ -175,3 +195,10 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch


### PR DESCRIPTION
Addressing:
```
E1109 14:08:25.396770       1 reflector.go:138] pkg/mod/k8s.io/client-go@v0.20.6/tools/cache/reflector.go:167: Failed to watch *v1.DaemonSet: failed to list *v
1.DaemonSet: daemonsets.apps is forbidden: User "system:serviceaccount:falcon-operator:falcon-operator" cannot list resource "daemonsets" in API group "apps" a
t the cluster scope
```