### PR TITLE
Do not assign operator SA to the daemonset

### DIFF
--- a/pkg/assets/node/daemonset.go
+++ b/pkg/assets/node/daemonset.go
@@ -80,7 +80,6 @@ func daemonset(dsName string, node *falconv1alpha1.FalconNodeSensor) *appsv1.Dae
 					HostPID:                       hostpid,
 					HostIPC:                       hostipc,
 					HostNetwork:                   hostnetwork,
-					ServiceAccountName:            common.OperatorServiceAccountName,
 					TerminationGracePeriodSeconds: getTermGracePeriod(node),
 					InitContainers: []corev1.Container{
 						{

--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -13,6 +13,4 @@ const (
 	FalconPartOfKey       = "crowdstrike.com/part-of"
 	FalconProviderKey     = "crowdstrike.com/provider"
 	FalconControllerKey   = "crowdstrike.com/created-by"
-
-	OperatorServiceAccountName = "falcon-operator"
 )


### PR DESCRIPTION
We must not leak the permissions needed by the operator to the deamonset.

Further, falcon-operator service account is only available in the namespace
operator is running in. falcon-operator service account is not available in any
other namespace, meaning the deployment to different namespace will be assured
to fail.