### PR TITLE
Daemonset: fix the name of the configmap for the daemonset

### DIFF
--- a/pkg/assets/node/daemonset.go
+++ b/pkg/assets/node/daemonset.go
@@ -111,7 +111,7 @@ func daemonset(dsName string, node *falconv1alpha1.FalconNodeSensor) *appsv1.Dae
 								{
 									ConfigMapRef: &corev1.ConfigMapEnvSource{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: dsName,
+											Name: dsName + "-config",
 										},
 									},
 								},


### PR DESCRIPTION
Addressing:
```
4s          Warning   Failed             pod/falcon-node-sensor-kqzpd   Error: configmap "falcon-node-sensor" not found
```