### PR TITLE
Fix broken image push

### DIFF
--- a/pkg/falcon_container/falcon_registry/registry.go
+++ b/pkg/falcon_container/falcon_registry/registry.go
@@ -52,6 +52,10 @@ func (reg *FalconRegistry) Pulltoken() ([]byte, error) {
 }
 
 func (reg *FalconRegistry) PullInfo(ctx context.Context, versionRequested *string) (falconTag string, falconImage types.ImageReference, systemContext *types.SystemContext, err error) {
+	systemContext, err = reg.systemContext()
+	if err != nil {
+		return
+	}
 	falconTag, err = reg.LastContainerTag(ctx, versionRequested)
 	if err != nil {
 		return

--- a/pkg/falcon_container_deployer/job_pullsecret.go
+++ b/pkg/falcon_container_deployer/job_pullsecret.go
@@ -50,6 +50,7 @@ func (d *FalconContainerDeployer) CreateJobSecret() error {
 		Data: map[string][]byte{
 			".dockerconfigjson": pulltoken,
 		},
+		Type: corev1.SecretTypeDockerConfigJson,
 	}
 	err = ctrl.SetControllerReference(d.Instance, secret, d.Scheme)
 	if err != nil {


### PR DESCRIPTION
Addressing:
```
2021-11-16T13:16:20.712Z        ERROR   controller-runtime.manager.controller.falconcontainer   Reconciler error        {"reconciler group": "falcon.crowdstrike.com", "reconciler kind": "FalconContainer", "name": "default", "namespace": "", "error": "Cannot refresh Falcon Container image: initializing source docker
://registry.crowdstrike.com/falcon-container/us-1/release/falcon-sensor:6.31.0-1409.container.x86_64.Release.US-1: unable to retrieve auth token: invalid username/password: unknown: Authentication is required"}
```

Introduced by ed57c6a156a3573df699a826d9f135c5c937f28f.