### PR TITLE
Fix broken deployment on openshift 4.7

### DIFF
--- a/bundle/manifests/falcon-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/falcon-operator.clusterserviceversion.yaml
@@ -397,7 +397,10 @@ spec:
                 securityContext:
                   allowPrivilegeEscalation: false
               securityContext:
+                fsGroup: 65532
+                runAsGroup: 65532
                 runAsNonRoot: true
+                runAsUser: 65532
               serviceAccountName: falcon-operator
               terminationGracePeriodSeconds: 10
       permissions:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -24,6 +24,9 @@ spec:
     spec:
       securityContext:
         runAsNonRoot: true
+        runAsGroup: 65532
+        runAsUser: 65532
+        fsGroup: 65532
       containers:
       - command:
         - /manager


### PR DESCRIPTION
Where distroless/rootless implementation is not able to work with randomized
UIDs.

Addressing:
```
container create failed: time="2022-01-24T18:25:30Z" level=error
msg="container_linux.go:366: starting container process caused:
chdir to cwd (\"/home/nonroot\") set in config.json failed: permission denied"
```

/cc @jhseceng 