### PR TITLE
Operator should drop various capabilities

### DIFF
--- a/bundle/manifests/falcon-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/falcon-operator.clusterserviceversion.yaml
@@ -398,6 +398,11 @@ spec:
                     memory: 20Mi
                 securityContext:
                   allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
+                  privileged: false
+                  readOnlyRootFilesystem: true
               securityContext:
                 fsGroup: 65532
                 runAsGroup: 65532

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -27,6 +27,7 @@ spec:
         runAsGroup: 65532
         runAsUser: 65532
         fsGroup: 65532
+        runAsNonRoot: true
       containers:
       - command:
         - /manager
@@ -36,6 +37,11 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
         livenessProbe:
           httpGet:
             path: /healthz

--- a/deploy/falcon-operator.yaml
+++ b/deploy/falcon-operator.yaml
@@ -664,6 +664,7 @@ spec:
     spec:
       securityContext:
         fsGroup: 65534
+        runAsNonRoot: true
       containers:
       - args:
         - --leader-elect
@@ -693,5 +694,10 @@ spec:
             memory: 20Mi
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
       serviceAccountName: falcon-operator
       terminationGracePeriodSeconds: 10

--- a/deploy/parts/operator.yaml
+++ b/deploy/parts/operator.yaml
@@ -36,6 +36,7 @@ spec:
     spec:
       securityContext:
         fsGroup: 65534
+        runAsNonRoot: true
       containers:
       - args:
         - --leader-elect
@@ -65,5 +66,10 @@ spec:
             memory: 20Mi
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
       serviceAccountName: falcon-operator
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
to allow easy adoption of the operator on security hardened clusters.