### PR TITLE
Error out explicitly when deployed on OpenShift with disabled registry

### DIFF
--- a/pkg/falcon_container_deployer/image_push.go
+++ b/pkg/falcon_container_deployer/image_push.go
@@ -65,6 +65,10 @@ func (d *FalconContainerDeployer) registryUri() (string, error) {
 		if err != nil {
 			return "", err
 		}
+		if imageStream.Status.DockerImageRepository == "" {
+			return "", fmt.Errorf("Unable to find route to OpenShift on-cluster registry. Please verify that OpenShift on-cluster registry is up and running")
+		}
+
 		return imageStream.Status.DockerImageRepository, nil
 	case falconv1alpha1.RegistryTypeGCR:
 		projectId, err := gcp.GetProjectID()


### PR DESCRIPTION
This may turn out to be useful for users who deploy openshift without on-cluster registry, while they instruct operator to use that non-existent openshift on-cluster registry.