### PR TITLE
Revert a part of a recent hardening

### DIFF
--- a/bundle/manifests/falcon-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/falcon-operator.clusterserviceversion.yaml
@@ -402,7 +402,6 @@ spec:
                     drop:
                     - ALL
                   privileged: false
-                  readOnlyRootFilesystem: true
               securityContext:
                 fsGroup: 65532
                 runAsGroup: 65532

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -41,7 +41,6 @@ spec:
             drop:
               - ALL
           privileged: false
-          readOnlyRootFilesystem: true
         livenessProbe:
           httpGet:
             path: /healthz

--- a/deploy/falcon-operator.yaml
+++ b/deploy/falcon-operator.yaml
@@ -698,6 +698,5 @@ spec:
             drop:
               - ALL
           privileged: false
-          readOnlyRootFilesystem: true
       serviceAccountName: falcon-operator
       terminationGracePeriodSeconds: 10

--- a/deploy/parts/operator.yaml
+++ b/deploy/parts/operator.yaml
@@ -70,6 +70,5 @@ spec:
             drop:
               - ALL
           privileged: false
-          readOnlyRootFilesystem: true
       serviceAccountName: falcon-operator
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
Interestingly, the hardening does not break the workflow on GKE, but it does break on the latest OpenShift.

Addressing: 
```
2022-02-02T10:14:14.379Z        ERROR   controller-runtime.manager.controller.falconcontainer      Reconciler error        {"reconciler group": "falcon.crowdstrik
e.com", "reconciler kind": "FalconContainer", "name": "my-setup", "namespace": "", "error": "Cannot refresh Falcon Container image: open /tmp/.dockercfg: read-onl
y file system"}
```