### PR TITLE
Fix GKE depoyment script to work with broader range of shell interpreters

### DIFF
--- a/docs/deployment/gke/run
+++ b/docs/deployment/gke/run
@@ -47,7 +47,7 @@ OPERATOR_NAMESPACE=falcon-operator
 if kubectl get crd catalogsources.operators.coreos.com > /dev/null 2>&1; then
     # Installation using operator OLM and operator sdk
     if ! type operator-sdk > /dev/null 2>&1; then
-        export ARCH=$(case $(uname -m) in x86_64) echo -n amd64 ;; aarch64) echo -n arm64 ;; *) echo -n $(uname -m) ;; esac)
+        export ARCH=$(uname -m | sed 's/aarch64/arm64/;s/x86_64/amd64/')
         export OS=$(uname | awk '{print tolower($0)}')
         export OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/v1.8.0
         curl -s -LO ${OPERATOR_SDK_DL_URL}/operator-sdk_${OS}_${ARCH}


### PR DESCRIPTION
Addressing:
```
$ bash -cx 'source <(curl -s https://raw.githubusercontent.com/CrowdStrike/falcon-operator/main/docs/deployment/gke/run)'
+ source /dev/fd/63
++ curl -s https://raw.githubusercontent.com/CrowdStrike/falcon-operator/main/docs/deployment/gke/run

$ (23) Failed writing body
```

@MPH13 