### PR TITLE
Remove controller-manager uid and gid settings

### DIFF
--- a/bundle/manifests/falcon-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/falcon-operator.clusterserviceversion.yaml
@@ -433,10 +433,7 @@ spec:
                     - ALL
                   privileged: false
               securityContext:
-                fsGroup: 65532
-                runAsGroup: 65532
                 runAsNonRoot: true
-                runAsUser: 65532
               serviceAccountName: falcon-operator-controller-manager
               terminationGracePeriodSeconds: 10
       permissions:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -26,10 +26,6 @@ spec:
     spec:
       securityContext:
         runAsNonRoot: true
-        runAsGroup: 65532
-        runAsUser: 65532
-        fsGroup: 65532
-        runAsNonRoot: true
       containers:
       - command:
         - /manager


### PR DESCRIPTION
- Current uid/gid settings for the controller manager break on more security conscious
  kubernetes distros where uid/gid is generated off of a random uid range that might
  require uid/gid to be > 65000