### PR TITLE
Addressing inability to upgrade the operator

### DIFF
--- a/bundle/manifests/falcon-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/falcon-operator.clusterserviceversion.yaml
@@ -408,7 +408,6 @@ spec:
                 - name: OPERATOR_NAME
                   value: falcon-operator
                 image: quay.io/crowdstrike/falcon-operator:latest
-                imagePullPolicy: IfNotPresent
                 livenessProbe:
                   httpGet:
                     path: /healthz

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -33,7 +33,6 @@ spec:
         - --leader-elect
         image: controller:latest
         name: manager
-        imagePullPolicy: IfNotPresent
         env:
           - name: WATCH_NAMESPACE
             valueFrom:


### PR DESCRIPTION
This partly reverts e09c4abcb1723e13fab2b0a40bb6471a0b62bab6.

We have seen behaviour where the cluster that would have the operator installed previously, would never pick up the latest bits