### PR TITLE
Frontdoor: Documentation for GKE node upgrade process

### DIFF
--- a/docs/deployment/gke/README.md
+++ b/docs/deployment/gke/README.md
@@ -25,6 +25,16 @@ This document will guide you through the installation of falcon-operator and dep
    bash -c 'source <(curl -s https://raw.githubusercontent.com/CrowdStrike/falcon-operator/main/docs/deployment/gke/run)'
    ```
 
+  Note :
+   - By default, Falcon Container sensor injector is configured to monitor all namespaces. For GKE cluster/Node upgrade, explicitly label the kube-public and kube-system namespace to not be monitored by Crowdstrike. Also falcon-operator and falcon-system namespaces should be labeled to disabled.
+
+    kubectl label namespace falcon-operator sensor.falcon-system.crowdstrike.com/injection=disabled
+    kubectl label namespace falcon-system sensor.falcon-system.crowdstrike.com/injection=disabled
+    kubectl label namespace kube-system sensor.falcon-system.crowdstrike.com/injection=disabled
+    kubectl label namespace kube-public sensor.falcon-system.crowdstrike.com/injection=disabled
+
+    This will ensure that, any pod related to k8 control plane and Falcon are not forwarded to the injector
+
 ## Uninstall Steps
 
  - To uninstall Falcon Container simply remove FalconContainer resource. The operator will uninstall Falcon Container product from the cluster.


### PR DESCRIPTION
During GKE node upgrades, if nodes are stuck and you are seeing below injector errors. 

```
Internal error occurred: failed calling webhook "injector.falcon-system.svc": Post "[https://injector.falcon-system.svc:443/mutate?timeout=30s](https://urldefense.com/v3/__https://isolate.menlosecurity.com/1/3735926845/https:/injector.falcon-system.svc:443/mutate?timeout=30s__;!!K-YMnnUXXw!QQQMR38gOSOmGruWvi1MtqLmvd82wQ_UewCp2kqaeadaeWwadRNyTNX9_n4zg6NQDmnsIwB9Lbne$)": EOF
```

Explicitly label the kube-public and kube-system namespace to be not monitored by Crowdstrike. Also falcon-operator and falcon-system namespaces should be labeled to disabled. Updated the documentation with steps. 
