### PR TITLE
Node: Refactor FalconAPI usage and fix #228

### DIFF
--- a/controllers/falcon/falconnodesensor_controller.go
+++ b/controllers/falcon/falconnodesensor_controller.go
@@ -7,10 +7,10 @@ import (
 
 	falconv1alpha1 "github.com/crowdstrike/falcon-operator/apis/falcon/v1alpha1"
 	common_assets "github.com/crowdstrike/falcon-operator/pkg/assets"
-	"github.com/crowdstrike/falcon-operator/pkg/node/assets"
 	"github.com/crowdstrike/falcon-operator/pkg/common"
-	"github.com/crowdstrike/falcon-operator/pkg/falcon_api"
 	"github.com/crowdstrike/falcon-operator/pkg/k8s_utils"
+	"github.com/crowdstrike/falcon-operator/pkg/node"
+	"github.com/crowdstrike/falcon-operator/pkg/node/assets"
 	"github.com/crowdstrike/falcon-operator/pkg/registry/pulltoken"
 	"github.com/go-logr/logr"
 	securityv1 "github.com/openshift/api/security/v1"
@@ -104,12 +104,12 @@ func (r *FalconNodeSensorReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		}
 	}
 
-	cid, err := falcon_api.FalconCID(ctx, nodesensor.Spec.Falcon.CID, nodesensor.Spec.FalconAPI.ApiConfig())
+	config, err := node.NewConfigCache(ctx, logger, nodesensor)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
 
-	sensorConf, updated, err := r.handleConfigMaps(ctx, cid, nodesensor, logger)
+	sensorConf, updated, err := r.handleConfigMaps(ctx, config.CID(), nodesensor, logger)
 	if err != nil {
 		logger.Error(err, "error handling configmap")
 		return ctrl.Result{}, err

--- a/controllers/falcon/falconnodesensor_controller.go
+++ b/controllers/falcon/falconnodesensor_controller.go
@@ -128,7 +128,7 @@ func (r *FalconNodeSensorReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		return ctrl.Result{}, err
 	}
 
-	image, err := node.GetFalconImage(ctx, nodesensor)
+	image, err := config.GetImageURI(ctx)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/controllers/falcon/falconnodesensor_controller.go
+++ b/controllers/falcon/falconnodesensor_controller.go
@@ -289,7 +289,7 @@ func (r *FalconNodeSensorReconciler) handleCrowdStrikeSecrets(ctx context.Contex
 }
 
 func (r *FalconNodeSensorReconciler) nodeSensorConfigmap(name string, config *node.ConfigCache, nodesensor *falconv1alpha1.FalconNodeSensor) (*corev1.ConfigMap, error) {
-	cm := assets.DaemonsetConfigMap(name, nodesensor.TargetNs(), config, &nodesensor.Spec.Falcon)
+	cm := assets.DaemonsetConfigMap(name, nodesensor.TargetNs(), config)
 
 	err := controllerutil.SetControllerReference(nodesensor, cm, r.Scheme)
 	if err != nil {

--- a/controllers/falcon/falconnodesensor_controller.go
+++ b/controllers/falcon/falconnodesensor_controller.go
@@ -128,7 +128,7 @@ func (r *FalconNodeSensorReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		return ctrl.Result{}, err
 	}
 
-	image, err := common.GetFalconImage(ctx, nodesensor)
+	image, err := node.GetFalconImage(ctx, nodesensor)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/pkg/common/funcs.go
+++ b/pkg/common/funcs.go
@@ -1,15 +1,12 @@
 package common
 
 import (
-	"context"
 	"encoding/base64"
-	"fmt"
 	"regexp"
 	"strconv"
 	"strings"
 
 	falconv1alpha1 "github.com/crowdstrike/falcon-operator/apis/falcon/v1alpha1"
-	"github.com/crowdstrike/falcon-operator/pkg/registry/falcon_registry"
 	sprigcrypto "github.com/crowdstrike/falcon-operator/pkg/sprig"
 	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/kubernetes"
@@ -23,33 +20,6 @@ func InitContainerArgs() []string {
 			" && " +
 			"touch " + FalconStoreFile,
 	}
-}
-
-func GetFalconImage(ctx context.Context, nodesensor *falconv1alpha1.FalconNodeSensor) (string, error) {
-	if nodesensor.Spec.Node.ImageOverride != "" {
-		return nodesensor.Spec.Node.ImageOverride, nil
-	}
-
-	if nodesensor.Spec.FalconAPI == nil {
-		return "", fmt.Errorf("Missing falcon_api configuration")
-	}
-
-	cloud, err := nodesensor.Spec.FalconAPI.FalconCloud(ctx)
-	if err != nil {
-		return "", err
-	}
-	imageUri := falcon_registry.ImageURINode(cloud)
-
-	registry, err := falcon_registry.NewFalconRegistry(ctx, nodesensor.Spec.FalconAPI.ApiConfig())
-	if err != nil {
-		return "", err
-	}
-	imageTag, err := registry.LastNodeTag(ctx, nil)
-	if err != nil {
-		return "", err
-	}
-
-	return fmt.Sprintf("%s:%s", imageUri, imageTag), nil
 }
 
 func FalconSensorConfig(falconsensor *falconv1alpha1.FalconSensor, cid string) map[string]string {

--- a/pkg/common/funcs.go
+++ b/pkg/common/funcs.go
@@ -3,10 +3,8 @@ package common
 import (
 	"encoding/base64"
 	"regexp"
-	"strconv"
 	"strings"
 
-	falconv1alpha1 "github.com/crowdstrike/falcon-operator/apis/falcon/v1alpha1"
 	sprigcrypto "github.com/crowdstrike/falcon-operator/pkg/sprig"
 	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/kubernetes"
@@ -20,36 +18,6 @@ func InitContainerArgs() []string {
 			" && " +
 			"touch " + FalconStoreFile,
 	}
-}
-
-func FalconSensorConfig(falconsensor *falconv1alpha1.FalconSensor, cid string) map[string]string {
-	sensorConfig := make(map[string]string)
-	if cid != "" {
-		sensorConfig["FALCONCTL_OPT_CID"] = cid
-	}
-	if falconsensor.APD != nil {
-		sensorConfig["FALCONCTL_OPT_APD"] = strconv.FormatBool(*falconsensor.APD)
-	}
-	if falconsensor.APH != "" {
-		sensorConfig["FALCONCTL_OPT_APH"] = falconsensor.APH
-	}
-	if falconsensor.APP != nil {
-		sensorConfig["FALCONCTL_OPT_APP"] = strconv.Itoa(*falconsensor.APP)
-	}
-	if falconsensor.Billing != "" {
-		sensorConfig["FALCONCTL_OPT_BILLING"] = falconsensor.Billing
-	}
-	if falconsensor.PToken != "" {
-		sensorConfig["FALCONCTL_OPT_PROVISIONING_TOKEN"] = falconsensor.PToken
-	}
-	if len(falconsensor.Tags) > 0 {
-		sensorConfig["FALCONCTL_OPT_TAGS"] = strings.Join(falconsensor.Tags, ",")
-	}
-	if falconsensor.Trace != "" {
-		sensorConfig["FALCONCTL_OPT_TRACE"] = falconsensor.Trace
-	}
-
-	return sensorConfig
 }
 
 func FCAdmissionReviewVersions() []string {

--- a/pkg/falcon_api/falcon_api.go
+++ b/pkg/falcon_api/falcon_api.go
@@ -54,11 +54,11 @@ func CCID(ctx context.Context, client *client.CrowdStrikeAPISpecification) (stri
 }
 
 func FalconCID(ctx context.Context, cid *string, fa *falcon.ApiConfig) (string, error) {
-	fa.Context = ctx
 	if cid != nil {
 		return *cid, nil
 	}
 
+	fa.Context = ctx
 	client, err := falcon.NewClient(fa)
 	if err != nil {
 		return "", err

--- a/pkg/node/assets/configmap.go
+++ b/pkg/node/assets/configmap.go
@@ -1,4 +1,4 @@
-package node
+package assets
 
 import (
 	falconv1alpha1 "github.com/crowdstrike/falcon-operator/apis/falcon/v1alpha1"

--- a/pkg/node/assets/configmap.go
+++ b/pkg/node/assets/configmap.go
@@ -3,12 +3,13 @@ package assets
 import (
 	falconv1alpha1 "github.com/crowdstrike/falcon-operator/apis/falcon/v1alpha1"
 	"github.com/crowdstrike/falcon-operator/pkg/common"
+	"github.com/crowdstrike/falcon-operator/pkg/node"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func DaemonsetConfigMap(dsname string, nsname string, cid string, falconsensor *falconv1alpha1.FalconSensor) *corev1.ConfigMap {
-	configData := common.FalconSensorConfig(falconsensor, cid)
+func DaemonsetConfigMap(dsname string, nsname string, config *node.ConfigCache, falconsensor *falconv1alpha1.FalconSensor) *corev1.ConfigMap {
+	configData := common.FalconSensorConfig(falconsensor, config.CID())
 
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/node/assets/configmap.go
+++ b/pkg/node/assets/configmap.go
@@ -1,16 +1,13 @@
 package assets
 
 import (
-	falconv1alpha1 "github.com/crowdstrike/falcon-operator/apis/falcon/v1alpha1"
 	"github.com/crowdstrike/falcon-operator/pkg/common"
 	"github.com/crowdstrike/falcon-operator/pkg/node"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func DaemonsetConfigMap(dsname string, nsname string, config *node.ConfigCache, falconsensor *falconv1alpha1.FalconSensor) *corev1.ConfigMap {
-	configData := common.FalconSensorConfig(falconsensor, config.CID())
-
+func DaemonsetConfigMap(dsname string, nsname string, config *node.ConfigCache) *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      dsname,
@@ -25,6 +22,6 @@ func DaemonsetConfigMap(dsname string, nsname string, config *node.ConfigCache, 
 				common.FalconControllerKey:   "controller-manager",
 			},
 		},
-		Data: configData,
+		Data: config.SensorEnvVars(),
 	}
 }

--- a/pkg/node/assets/daemonset.go
+++ b/pkg/node/assets/daemonset.go
@@ -1,4 +1,4 @@
-package node
+package assets
 
 import (
 	falconv1alpha1 "github.com/crowdstrike/falcon-operator/apis/falcon/v1alpha1"

--- a/pkg/node/config_cache.go
+++ b/pkg/node/config_cache.go
@@ -7,6 +7,7 @@ import (
 	falconv1alpha1 "github.com/crowdstrike/falcon-operator/apis/falcon/v1alpha1"
 	"github.com/crowdstrike/falcon-operator/pkg/falcon_api"
 	"github.com/crowdstrike/falcon-operator/pkg/registry/falcon_registry"
+	"github.com/crowdstrike/falcon-operator/pkg/registry/pulltoken"
 	"github.com/crowdstrike/gofalcon/falcon"
 	"github.com/go-logr/logr"
 )
@@ -28,6 +29,18 @@ func (cc *ConfigCache) GetImageURI(ctx context.Context) (string, error) {
 		cc.imageUri, err = getFalconImage(ctx, cc.nodesensor)
 	}
 	return cc.imageUri, err
+}
+
+func (cc *ConfigCache) GetPullToken(ctx context.Context) ([]byte, error) {
+	var err error
+	if cc.pullToken == nil {
+		if cc.nodesensor.Spec.FalconAPI == nil {
+			return nil, fmt.Errorf("Missing falcon_api configuration")
+		}
+		cc.pullToken, err = pulltoken.CrowdStrike(ctx, cc.nodesensor.Spec.FalconAPI.ApiConfig())
+
+	}
+	return cc.pullToken, err
 }
 
 func NewConfigCache(ctx context.Context, logger logr.Logger, nodesensor *falconv1alpha1.FalconNodeSensor) (*ConfigCache, error) {

--- a/pkg/node/config_cache.go
+++ b/pkg/node/config_cache.go
@@ -1,0 +1,29 @@
+package node
+
+import (
+	"context"
+
+	falconv1alpha1 "github.com/crowdstrike/falcon-operator/apis/falcon/v1alpha1"
+	"github.com/crowdstrike/falcon-operator/pkg/falcon_api"
+	"github.com/go-logr/logr"
+)
+
+// ConfigCache holds config values for node sensor. Those values are either provided by user or fetched dynamically. That happens transparently to the caller.
+type ConfigCache struct {
+	cid string
+}
+
+func (cc *ConfigCache) CID() string {
+	return cc.cid
+}
+
+func NewConfigCache(ctx context.Context, logger logr.Logger, nodesensor *falconv1alpha1.FalconNodeSensor) (*ConfigCache, error) {
+	cid, err := falcon_api.FalconCID(ctx, nodesensor.Spec.Falcon.CID, nodesensor.Spec.FalconAPI.ApiConfig())
+	if err != nil {
+		return nil, err
+	}
+
+	return &ConfigCache{
+		cid: cid,
+	}, nil
+}

--- a/pkg/node/config_cache.go
+++ b/pkg/node/config_cache.go
@@ -32,15 +32,10 @@ func (cc *ConfigCache) GetImageURI(ctx context.Context) (string, error) {
 }
 
 func (cc *ConfigCache) GetPullToken(ctx context.Context) ([]byte, error) {
-	var err error
-	if cc.pullToken == nil {
-		if cc.nodesensor.Spec.FalconAPI == nil {
-			return nil, fmt.Errorf("Missing falcon_api configuration")
-		}
-		cc.pullToken, err = pulltoken.CrowdStrike(ctx, cc.nodesensor.Spec.FalconAPI.ApiConfig())
-
+	if cc.nodesensor.Spec.FalconAPI == nil {
+		return nil, fmt.Errorf("Missing falcon_api configuration")
 	}
-	return cc.pullToken, err
+	return pulltoken.CrowdStrike(ctx, cc.nodesensor.Spec.FalconAPI.ApiConfig())
 }
 
 func NewConfigCache(ctx context.Context, logger logr.Logger, nodesensor *falconv1alpha1.FalconNodeSensor) (*ConfigCache, error) {

--- a/pkg/node/config_cache.go
+++ b/pkg/node/config_cache.go
@@ -3,6 +3,8 @@ package node
 import (
 	"context"
 	"fmt"
+	"strconv"
+	"strings"
 
 	falconv1alpha1 "github.com/crowdstrike/falcon-operator/apis/falcon/v1alpha1"
 	"github.com/crowdstrike/falcon-operator/pkg/falcon_api"
@@ -36,6 +38,37 @@ func (cc *ConfigCache) GetPullToken(ctx context.Context) ([]byte, error) {
 		return nil, fmt.Errorf("Missing falcon_api configuration")
 	}
 	return pulltoken.CrowdStrike(ctx, cc.nodesensor.Spec.FalconAPI.ApiConfig())
+}
+
+func (cc *ConfigCache) SensorEnvVars() map[string]string {
+	sensorConfig := make(map[string]string)
+	falconsensor := cc.nodesensor.Spec.Falcon
+
+	if cc.cid != "" {
+		sensorConfig["FALCONCTL_OPT_CID"] = cc.cid
+	}
+	if falconsensor.APD != nil {
+		sensorConfig["FALCONCTL_OPT_APD"] = strconv.FormatBool(*falconsensor.APD)
+	}
+	if falconsensor.APH != "" {
+		sensorConfig["FALCONCTL_OPT_APH"] = falconsensor.APH
+	}
+	if falconsensor.APP != nil {
+		sensorConfig["FALCONCTL_OPT_APP"] = strconv.Itoa(*falconsensor.APP)
+	}
+	if falconsensor.Billing != "" {
+		sensorConfig["FALCONCTL_OPT_BILLING"] = falconsensor.Billing
+	}
+	if falconsensor.PToken != "" {
+		sensorConfig["FALCONCTL_OPT_PROVISIONING_TOKEN"] = falconsensor.PToken
+	}
+	if len(falconsensor.Tags) > 0 {
+		sensorConfig["FALCONCTL_OPT_TAGS"] = strings.Join(falconsensor.Tags, ",")
+	}
+	if falconsensor.Trace != "" {
+		sensorConfig["FALCONCTL_OPT_TRACE"] = falconsensor.Trace
+	}
+	return sensorConfig
 }
 
 func NewConfigCache(ctx context.Context, logger logr.Logger, nodesensor *falconv1alpha1.FalconNodeSensor) (*ConfigCache, error) {

--- a/pkg/node/config_cache.go
+++ b/pkg/node/config_cache.go
@@ -2,21 +2,26 @@ package node
 
 import (
 	"context"
+	"fmt"
 
 	falconv1alpha1 "github.com/crowdstrike/falcon-operator/apis/falcon/v1alpha1"
 	"github.com/crowdstrike/falcon-operator/pkg/falcon_api"
 	"github.com/crowdstrike/gofalcon/falcon"
+	"github.com/crowdstrike/falcon-operator/pkg/registry/falcon_registry"
 	"github.com/go-logr/logr"
 )
 
 // ConfigCache holds config values for node sensor. Those values are either provided by user or fetched dynamically. That happens transparently to the caller.
 type ConfigCache struct {
 	cid string
+	imageUri string
 }
 
 func (cc *ConfigCache) CID() string {
 	return cc.cid
 }
+
+
 
 func NewConfigCache(ctx context.Context, logger logr.Logger, nodesensor *falconv1alpha1.FalconNodeSensor) (*ConfigCache, error) {
 	var apiConfig *falcon.ApiConfig
@@ -38,4 +43,31 @@ func NewConfigCache(ctx context.Context, logger logr.Logger, nodesensor *falconv
 	}
 
 	return &cache, nil
+}
+
+func GetFalconImage(ctx context.Context, nodesensor *falconv1alpha1.FalconNodeSensor) (string, error) {
+	if nodesensor.Spec.Node.ImageOverride != "" {
+		return nodesensor.Spec.Node.ImageOverride, nil
+	}
+
+	if nodesensor.Spec.FalconAPI == nil {
+		return "", fmt.Errorf("Missing falcon_api configuration")
+	}
+
+	cloud, err := nodesensor.Spec.FalconAPI.FalconCloud(ctx)
+	if err != nil {
+		return "", err
+	}
+	imageUri := falcon_registry.ImageURINode(cloud)
+
+	registry, err := falcon_registry.NewFalconRegistry(ctx, nodesensor.Spec.FalconAPI.ApiConfig())
+	if err != nil {
+		return "", err
+	}
+	imageTag, err := registry.LastNodeTag(ctx, nil)
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("%s:%s", imageUri, imageTag), nil
 }

--- a/pkg/node/config_cache.go
+++ b/pkg/node/config_cache.go
@@ -5,6 +5,7 @@ import (
 
 	falconv1alpha1 "github.com/crowdstrike/falcon-operator/apis/falcon/v1alpha1"
 	"github.com/crowdstrike/falcon-operator/pkg/falcon_api"
+	"github.com/crowdstrike/gofalcon/falcon"
 	"github.com/go-logr/logr"
 )
 
@@ -18,12 +19,23 @@ func (cc *ConfigCache) CID() string {
 }
 
 func NewConfigCache(ctx context.Context, logger logr.Logger, nodesensor *falconv1alpha1.FalconNodeSensor) (*ConfigCache, error) {
-	cid, err := falcon_api.FalconCID(ctx, nodesensor.Spec.Falcon.CID, nodesensor.Spec.FalconAPI.ApiConfig())
-	if err != nil {
-		return nil, err
+	var apiConfig *falcon.ApiConfig
+	var err error
+	cache := ConfigCache{}
+
+	if nodesensor.Spec.FalconAPI != nil {
+		apiConfig = nodesensor.Spec.FalconAPI.ApiConfig()
+		if nodesensor.Spec.FalconAPI.CID != nil {
+			cache.cid = *nodesensor.Spec.FalconAPI.CID
+		}
 	}
 
-	return &ConfigCache{
-		cid: cid,
-	}, nil
+	if cache.cid == "" {
+		cache.cid, err = falcon_api.FalconCID(ctx, nodesensor.Spec.Falcon.CID, apiConfig)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &cache, nil
 }


### PR DESCRIPTION
This PR
 - fixes #228 by not requiring API permissions if CID and imageOverride is provided by user
 - refactors nodesensor controller
   - to lesser the amount of responsibilities of nodesensor component
   - to concentrate Falcon API / configuration logic to a single file & object (node.ConfigCache)
   - to allow for slight performance boost by caching the config options that are fetched multiple times
   - to remove node-only-related functions from `./pkg/common`