### PR TITLE
fix: allow the toleration of control-plane nodes by default

### DIFF
--- a/apis/falcon/v1alpha1/falconnodesensor_types.go
+++ b/apis/falcon/v1alpha1/falconnodesensor_types.go
@@ -66,7 +66,7 @@ type FalconSensor struct {
 // +k8s:openapi-gen=true
 type FalconNodeSensorConfig struct {
 	// Specifies tolerations for custom taints. Defaults to allowing scheduling on all nodes.
-	// +kubebuilder:default={{operator: "Exists", effect: "NoSchedule"}, {operator: "Exists", effect: "NoExecute"}}
+	// +kubebuilder:default={{key: "node-role.kubernetes.io/master", operator: "Exists", effect: "NoSchedule"}, {key: "node-role.kubernetes.io/control-plane", operator: "Exists", effect: "NoSchedule"}}
 	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
 	// +kubebuilder:default=Always
 	ImagePullPolicy corev1.PullPolicy `json:"imagePullPolicy,omitempty"`

--- a/bundle/manifests/falcon.crowdstrike.com_falconnodesensors.yaml
+++ b/bundle/manifests/falcon.crowdstrike.com_falconnodesensors.yaml
@@ -145,8 +145,10 @@ spec:
                   tolerations:
                     default:
                     - effect: NoSchedule
+                      key: node-role.kubernetes.io/master
                       operator: Exists
-                    - effect: NoExecute
+                    - effect: NoSchedule
+                      key: node-role.kubernetes.io/control-plane
                       operator: Exists
                     description: Specifies tolerations for custom taints. Defaults
                       to allowing scheduling on all nodes.

--- a/config/crd/bases/falcon.crowdstrike.com_falconnodesensors.yaml
+++ b/config/crd/bases/falcon.crowdstrike.com_falconnodesensors.yaml
@@ -146,8 +146,10 @@ spec:
                   tolerations:
                     default:
                     - effect: NoSchedule
+                      key: node-role.kubernetes.io/master
                       operator: Exists
-                    - effect: NoExecute
+                    - effect: NoSchedule
+                      key: node-role.kubernetes.io/control-plane
                       operator: Exists
                     description: Specifies tolerations for custom taints. Defaults
                       to allowing scheduling on all nodes.

--- a/deploy/falcon-operator.yaml
+++ b/deploy/falcon-operator.yaml
@@ -381,8 +381,10 @@ spec:
                   tolerations:
                     default:
                     - effect: NoSchedule
+                      key: node-role.kubernetes.io/master
                       operator: Exists
-                    - effect: NoExecute
+                    - effect: NoSchedule
+                      key: node-role.kubernetes.io/control-plane
                       operator: Exists
                     description: Specifies tolerations for custom taints. Defaults
                       to allowing scheduling on all nodes.


### PR DESCRIPTION
aligns tolerations with helm-chart defaults

On EKS, when using a mix of both Node Groups and Fargate Profiles,
the falcon-operator custom resource tries to install the DaemonSet
pods on all nodes, not just EC2 Node Groups. By default, the
operator should create a DaemonSet that does not deploy to Fargate
Nodes.