### PR TITLE
Fix: "Failed to create new Configmap ... already exists"

### DIFF
--- a/main.go
+++ b/main.go
@@ -85,7 +85,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	setupLog.Info("setting up a mannager with", "watchNamespace", watchNamespace)
+	setupLog.Info("setting up manager to watch resources", "watchNamespace", watchNamespace)
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,
 		MetricsBindAddress:     metricsAddr,

--- a/main.go
+++ b/main.go
@@ -85,6 +85,7 @@ func main() {
 		os.Exit(1)
 	}
 
+	setupLog.Info("setting up a mannager with", "watchNamespace", watchNamespace)
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,
 		MetricsBindAddress:     metricsAddr,


### PR DESCRIPTION
Fixes #217

Addressing infinite loop with following error:
```
ERROR	controller.falconnodesensor	Failed to create new Configmap	{"reconciler group": "falcon.crowdstrike.com", "reconciler kind": "FalconNodeSensor", "name": "falcon-node-sensor", "namespace": "", "DaemonSet": "/falcon-node-sensor", "Configmap.Namespace": "falcon-system", "Configmap.Name": "falcon-node-sensor-config", "error": "configmaps \"falcon-node-sensor-config\" already exists"}
```

## Description of the problem:

The following events happen in the infinite loop
 - Get() of the config map returns NotFound
 - Create() of the config map returns AlreadyExists

For some reason, the cache of the Get command is never invalidated after
creation. We have seen this issue in EKS, but it may not be isolated to EKS.
We have not been able to reproduce this in house. And the root cause of the
cache not being properly invalidated is not known.

## Description of the solution:

We can easily tell in the code, when this happens and since it is non-fatal for
the purposes of the sensor deployment, we can safely proceed ignoring this
issue. Morever, we can force update the content of a given configmap to calm
down those who would think that it is needed.
