### PR TITLE
We cannot support deployment method confined to a single namespace

### DIFF
--- a/bundle/manifests/falcon-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/falcon-operator.clusterserviceversion.yaml
@@ -474,9 +474,9 @@ spec:
         serviceAccountName: falcon-operator-controller-manager
     strategy: deployment
   installModes:
-  - supported: true
+  - supported: false
     type: OwnNamespace
-  - supported: true
+  - supported: false
     type: SingleNamespace
   - supported: false
     type: MultiNamespace

--- a/config/manifests/bases/falcon-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/falcon-operator.clusterserviceversion.yaml
@@ -100,9 +100,9 @@ spec:
       deployments: null
     strategy: ""
   installModes:
-  - supported: true
+  - supported: false
     type: OwnNamespace
-  - supported: true
+  - supported: false
     type: SingleNamespace
   - supported: false
     type: MultiNamespace


### PR DESCRIPTION
Removing that option from openshift marketplace.
![Screenshot 2022-05-24 at 13 13 36](https://user-images.githubusercontent.com/6666052/170032412-06a2ec35-f935-4fc3-a769-1759c456ad10.png)

/cc @MPH13
