### PR TITLE
Enable Single Namespace in the CSV

### DIFF
--- a/bundle/manifests/falcon-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/falcon-operator.clusterserviceversion.yaml
@@ -551,9 +551,9 @@ spec:
         serviceAccountName: falcon-operator-controller-manager
     strategy: deployment
   installModes:
-  - supported: false
+  - supported: true
     type: OwnNamespace
-  - supported: false
+  - supported: true
     type: SingleNamespace
   - supported: false
     type: MultiNamespace

--- a/config/manifests/bases/falcon-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/falcon-operator.clusterserviceversion.yaml
@@ -174,9 +174,9 @@ spec:
       deployments: null
     strategy: ""
   installModes:
-  - supported: false
+  - supported: true
     type: OwnNamespace
-  - supported: false
+  - supported: true
     type: SingleNamespace
   - supported: false
     type: MultiNamespace

--- a/docs/operator.md
+++ b/docs/operator.md
@@ -7,6 +7,82 @@ kubectl -n falcon-operator logs -f deploy/falcon-operator-controller-manager -c 
 
 ## Operator Issues
 
+#### Configure to watch only the `falcon-system` namespace when using FalconNodeSensor
+
+Since the Falcon Operator is a global-scoped operator, it watches across resources and objects across all namespaces.
+For large clusters that might have large configmaps and secrets, this requires a lot of memory to be consumed which may be less than ideal.
+If you do not want the operator to watch globally when using the FalconNodeSensor resource, configure the operator to only watch the `falcon-system` namespace
+Please note that the following settings should not be configured when using the FalconContainer Resource.
+
+##### OpenShift CLI
+
+- If this is a brand new install and you are using the `oc` cli tool, create the following file:
+  ```
+  cat << EOF >> operatorgroup.yaml
+
+  apiVersion: operators.coreos.com/v1
+  kind: OperatorGroup
+  metadata:
+    name: falcon-operator-og
+  spec:
+    targetNamespaces:
+    - falcon-system
+  EOF
+  ```
+  The `OperatorGroup` will tell the operator to only watch a single namespace. It will also persist independently of the operator so that the setting will apply whenever 
+  the operator is installed, un-installed, or upgraded.
+
+- Create the Falcon Operator subscription to install from the console:
+  ```
+  cat << EOF >> sub.yaml
+  apiVersion: operators.coreos.com/v1alpha1
+  kind: Subscription
+  metadata:
+    name: falcon-operator-v0-5-4-sub
+  spec:
+    channel: alpha
+    name: falcon-operator
+    source: community-operators
+    sourceNamespace: openshift-marketplace
+    startingCSV: falcon-operator.v0.5.4
+  ```
+
+- Deploy the operator
+  ```
+  $ oc create -f operatorgroup.yaml -n falcon-operator
+  $ oc create -f sub.yaml -n falcon-operator
+  ```
+  The operator should now deploy while only watching the `falcon-system` namespace.
+
+- If you have already installed the operator, edit the auto-generated `OperatorGroup`:
+  ```
+  $ oc edit operatorgroup -n falcon-operator
+  ```
+
+- Add the following by replacing `spec: {}` with:
+  ```
+  spec: 
+    targetNamespaces:
+      - falcon-system
+  ```
+  Save the changes and the operator deployment will update and rollout a new deployment.
+
+##### OpenShift GUI
+
+##### EKS, AKS, GKE, and non-OpenShift or non-OLM installs
+
+- Configure the `WATCH_NAMESPACE` env variable by editing the Falcon Operator deployment configuration:
+  ```
+  $ kubectl edit deployment falcon-operator-controller-manager -n falcon-operator
+  ```
+
+- Add the `value` of `falcon-system` to the `WATCH_NAMESPACE` env variable, for example:
+  ```
+  - name: WATCH_NAMESPACE
+    value: 'falcon-system'
+  ```
+  Save the changes and the operator deployment will update and rollout a new deployment.
+
 #### ERROR setup failed to get watch namespace
 
 If the following error shows up in the controller manager logs:


### PR DESCRIPTION
- Allows watch_namespace to be supported in the CSV which is already enabled in main.go
- Allows customers to limit watch to a specific namespace as desired for the node sensor
- Preps for edge use-cases