### PR TITLE
Add pod deletecollection permissions to operator

### DIFF
--- a/bundle/manifests/falcon-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/falcon-operator.clusterserviceversion.yaml
@@ -228,6 +228,7 @@ spec:
           - pods
           verbs:
           - delete
+          - deletecollection
           - get
           - list
           - watch

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -21,6 +21,7 @@ rules:
   - pods
   verbs:
   - delete
+  - deletecollection
   - get
   - list
   - watch

--- a/controllers/falcon/falconnodesensor_controller.go
+++ b/controllers/falcon/falconnodesensor_controller.go
@@ -46,6 +46,8 @@ func (r *FalconNodeSensorReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
+// +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch;delete;deletecollection
+
 //+kubebuilder:rbac:groups=falcon.crowdstrike.com,resources=falconnodesensors,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=falcon.crowdstrike.com,resources=falconnodesensors/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=falcon.crowdstrike.com,resources=falconnodesensors/finalizers,verbs=update

--- a/deploy/falcon-operator.yaml
+++ b/deploy/falcon-operator.yaml
@@ -652,6 +652,7 @@ rules:
   - pods
   verbs:
   - delete
+  - deletecollection
   - get
   - list
   - watch

--- a/deploy/parts/role.yaml
+++ b/deploy/parts/role.yaml
@@ -18,6 +18,7 @@ rules:
   - pods
   verbs:
   - delete
+  - deletecollection
   - get
   - list
   - watch


### PR DESCRIPTION
DeleteAllOf, leveraged in https://github.com/CrowdStrike/falcon-operator/commit/5b8ea452d5dff81b31a8614182afbc1cb33923a3 relies upon the controller having deletecollection permissions over pods.