### PR TITLE
fix: manager configmap

### DIFF
--- a/deploy/falcon-operator.yaml
+++ b/deploy/falcon-operator.yaml
@@ -883,6 +883,7 @@ data:
 kind: ConfigMap
 metadata:
   name: falcon-operator
+  namespace: falcon-operator
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/deploy/parts/operator.yaml
+++ b/deploy/parts/operator.yaml
@@ -16,6 +16,7 @@ data:
 kind: ConfigMap
 metadata:
   name: falcon-operator
+  namespace: falcon-operator
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
non OLM install manifest for the manager configmap was missing a namespace definition e.g. `falcon-operator`, therefore the configmap was getting installed to the user's current kubectl context.