### PR TITLE
Changing ordering of items

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -265,5 +265,5 @@ deploy/parts/crd-falconcontainers.yaml: bundle/manifests/falcon.crowdstrike.com_
 deploy/parts/crd-falconnodesensors.yaml: bundle/manifests/falcon.crowdstrike.com_falconnodesensors.yaml
 	(echo "---"; cat $^ ) > $@
 
-deploy/falcon-operator.yaml: deploy/parts/crd-falconcontainers.yaml deploy/parts/crd-falconnodesensors.yaml deploy/parts/ns.yaml deploy/parts/role.yaml deploy/parts/service_account.yaml deploy/parts/role_binding.yaml deploy/parts/operator.yaml
+deploy/falcon-operator.yaml: deploy/parts/ns.yaml deploy/parts/crd-falconcontainers.yaml deploy/parts/crd-falconnodesensors.yaml deploy/parts/role.yaml deploy/parts/service_account.yaml deploy/parts/role_binding.yaml deploy/parts/operator.yaml
 	cat $^ > $@

--- a/deploy/falcon-operator.yaml
+++ b/deploy/falcon-operator.yaml
@@ -1,4 +1,9 @@
 ---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: falcon-operator
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -627,11 +632,6 @@ status:
     plural: ""
   conditions: null
   storedVersions: null
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: falcon-operator
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole


### PR DESCRIPTION
This fixes weird errors seen in terraform templates when using deploy/falcon-operator.yaml

Addressing:
```
│ Error: API response status: Failure
│
│   with module.falcon-operator.kubernetes_manifest.test["/api/v1/namespaces/falcon-operator/serviceaccounts/falcon-operator"],
│   on .terraform/modules/falcon-operator/manifest.tf line 11, in resource "kubernetes_manifest" "test":
│   11: resource "kubernetes_manifest" "test" {
│
│ namespaces "falcon-operator" not found
```

/cc @ffalor 