### PR TITLE
Prefer null value to empty string "" when setting env variables

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -35,7 +35,7 @@ spec:
         name: manager
         env:
           - name: WATCH_NAMESPACE
-            value: ""
+            value: null
           - name: POD_NAME
             valueFrom:
               fieldRef:

--- a/deploy/falcon-operator.yaml
+++ b/deploy/falcon-operator.yaml
@@ -914,7 +914,7 @@ spec:
         imagePullPolicy: Always
         env:
           - name: WATCH_NAMESPACE
-            value: ''
+            value: null
           - name: POD_NAME
             valueFrom:
               fieldRef:

--- a/deploy/parts/operator.yaml
+++ b/deploy/parts/operator.yaml
@@ -47,7 +47,7 @@ spec:
         imagePullPolicy: Always
         env:
           - name: WATCH_NAMESPACE
-            value: ''
+            value: null
           - name: POD_NAME
             valueFrom:
               fieldRef:

--- a/docs/operator.md
+++ b/docs/operator.md
@@ -100,7 +100,7 @@ and add something similar to the following lines:
 ```
         env:
           - name: WATCH_NAMESPACE
-            value: ''
+            value: null
           - name: POD_NAME
             valueFrom:
               fieldRef:
@@ -129,7 +129,7 @@ and changing `WATCH_NAMESPACE` to the following lines:
 ```
         env:
           - name: WATCH_NAMESPACE
-            value: ''
+            value: null
           - name: POD_NAME
             valueFrom:
               fieldRef:


### PR DESCRIPTION
When kubernetes receives environment variable settings like

         env:
           - name: WATCH_NAMESPACE
             value: ''

it will get re-written by contoller loop to

         env:
           - name: WATCH_NAMESPACE
             value: null

This is negligable most of the time. However, when deploying from terraform, following error aborts deployment as terraform k8s provider asserts for equality post deployment.

Addressing:
```
│ Error: Provider produced inconsistent result after apply │
│ When applying changes to module.falcon-operator.kubernetes_manifest.test["/apis/apps/v1/namespaces/falcon-operator/deployments/falcon-operator-controller-manager"], │ provider "provider[\"registry.terraform.io/hashicorp/kubernetes\"]" produced an unexpected new value: .object.spec.template.spec.containers[0].env[0].value: was │ cty.StringVal(""), but now null.
│
│ This is a bug in the provider, which should be reported in the provider's own issue tracker. ╵
```
/cc @ffalor 