### PR TITLE
fix: ensure falconstore is a file when initContainer runs

### DIFF
--- a/pkg/common/common_test.go
+++ b/pkg/common/common_test.go
@@ -14,7 +14,7 @@ type FakeDiscovery struct {
 }
 
 func TestInitContainerArgs(t *testing.T) {
-	want := []string{"-c", "mkdir -p /opt/CrowdStrike && touch /opt/CrowdStrike/falconstore"}
+	want := []string{"-c", `if [ -d "/opt/CrowdStrike/falconstore" ] ; then echo "Re-creating /opt/CrowdStrike/falconstore as it is a directory instead of a file"; rm -rf /opt/CrowdStrike/falconstore; fi; mkdir -p /opt/CrowdStrike && touch /opt/CrowdStrike/falconstore`}
 	if got := InitContainerArgs(); !reflect.DeepEqual(got, want) {
 		t.Errorf("InitContainerArgs() = %v, want %v", got, want)
 	}

--- a/pkg/common/funcs.go
+++ b/pkg/common/funcs.go
@@ -14,7 +14,8 @@ import (
 func InitContainerArgs() []string {
 	return []string{
 		"-c",
-		"mkdir -p " + FalconDataDir +
+		`if [ -d "/opt/CrowdStrike/falconstore" ] ; then echo "Re-creating /opt/CrowdStrike/falconstore as it is a directory instead of a file"; rm -rf /opt/CrowdStrike/falconstore; fi; ` +
+			"mkdir -p " + FalconDataDir +
 			" && " +
 			"touch " + FalconStoreFile,
 	}


### PR DESCRIPTION
- In some cases when the operator was not deployed correctly, Kubernetes would create the falconstore file as a directory. This adds the capability for the initContainer to fix that by deleting falconstore if it is a directory when it should be a file.