### PR TITLE
remove falconctlOpts to use default properties

### DIFF
--- a/bundle/manifests/falcon-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/falcon-operator.clusterserviceversion.yaml
@@ -12,15 +12,15 @@ metadata:
           },
           "spec": {
             "falcon": {
+              "tags": [
+                "sidecar"
+              ],
               "trace": "none"
             },
             "falcon_api": {
               "client_id": "PLEASE_FILL_IN",
               "client_secret": "PLEASE_FILL_IN",
               "cloud_region": "autodiscover"
-            },
-            "injector": {
-              "falconctlOpts": "--tags=test-cluster"
             },
             "registry": {
               "type": "crowdstrike"
@@ -35,6 +35,9 @@ metadata:
           },
           "spec": {
             "falcon": {
+              "tags": [
+                "daemonset"
+              ],
               "trace": "none"
             },
             "falcon_api": {

--- a/config/samples/falcon_v1alpha1_falconcontainer-all-options.yaml
+++ b/config/samples/falcon_v1alpha1_falconcontainer-all-options.yaml
@@ -23,6 +23,10 @@ spec:
       - tags2
     billing: metered
     trace: none
+    tags:
+      - sidecar
+      - tags1
+      - tags2
   injector:
     serviceAccount:
       name: default
@@ -31,7 +35,6 @@ spec:
         eks.amazonaws.com/role-arn: arn:aws:iam::111122223333:role/iam-role-name
         iam.gke.io/gcp-service-account: $GCP_SERVICE_ACCOUNT@$GCP_PROJECT_ID.iam.gserviceaccount.com
         annotation2: annotation-value
-    falconctlOpts: '--apd=disabled --tags=test-cluster,tags1,tags2'
     disableDefaultNamespaceInjection: true
     disableDefaultPodInjection: false
     imagePullPolicy: Always

--- a/config/samples/falcon_v1alpha1_falconcontainer.yaml
+++ b/config/samples/falcon_v1alpha1_falconcontainer.yaml
@@ -16,7 +16,7 @@ spec:
     cloud_region: autodiscover
   registry:
     type: crowdstrike
-  injector:
-    falconctlOpts: '--tags=test-cluster'
   falcon:
     trace: none
+    tags:
+      - sidecar

--- a/config/samples/falcon_v1alpha1_falconnodesensor-all-options.yaml
+++ b/config/samples/falcon_v1alpha1_falconnodesensor-all-options.yaml
@@ -43,7 +43,7 @@ spec:
     provisioning_token: 00001111
     cid: 00001111222233334444555566667777-12
     tags:
-      - test-cluster
+      - daemonset
       - tags1
       - tags2
     trace: none

--- a/config/samples/falcon_v1alpha1_falconnodesensor.yaml
+++ b/config/samples/falcon_v1alpha1_falconnodesensor.yaml
@@ -16,3 +16,5 @@ spec:
     cloud_region: autodiscover
   falcon:
     trace: none
+    tags:
+      - daemonset


### PR DESCRIPTION
Usage of `falconctlOpts` is not valid anymore.

`
Error from server (BadRequest): error when creating "falcon_v1alpha1_falconcontainer.yaml": FalconContainer in version "v1alpha1" cannot be handled as a FalconContainer: strict decoding error: unknown field "spec.injector.falconctlOpts"
`