### PR TITLE
adding default trace value in the yaml

### DIFF
--- a/bundle/manifests/falcon-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/falcon-operator.clusterserviceversion.yaml
@@ -11,6 +11,9 @@ metadata:
             "name": "default"
           },
           "spec": {
+            "falcon": {
+              "trace": "none"
+            },
             "falcon_api": {
               "client_id": "PLEASE_FILL_IN",
               "client_secret": "PLEASE_FILL_IN",
@@ -31,6 +34,9 @@ metadata:
             "name": "falcon-node-sensor"
           },
           "spec": {
+            "falcon": {
+              "trace": "none"
+            },
             "falcon_api": {
               "client_id": "PLEASE_FILL_IN",
               "client_secret": "PLEASE_FILL_IN",

--- a/config/samples/falcon_v1alpha1_falconcontainer.yaml
+++ b/config/samples/falcon_v1alpha1_falconcontainer.yaml
@@ -18,3 +18,5 @@ spec:
     type: crowdstrike
   injector:
     falconctlOpts: '--tags=test-cluster'
+  falcon:
+    trace: none

--- a/config/samples/falcon_v1alpha1_falconnodesensor.yaml
+++ b/config/samples/falcon_v1alpha1_falconnodesensor.yaml
@@ -14,3 +14,5 @@ spec:
     client_id: PLEASE_FILL_IN
     client_secret: PLEASE_FILL_IN
     cloud_region: autodiscover
+  falcon:
+    trace: none


### PR DESCRIPTION
Add the default trace value (`none`) in the online yaml file, so it easier to ask a user to change this value.
Adding it to the default yaml for reducing troubleshooting friction.