### PR TITLE
Do not deploy status: subresources outside OLM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -261,9 +261,10 @@ ifeq (, $(shell which operator-sdk))
 endif
 
 deploy/parts/crd-falconcontainers.yaml: bundle/manifests/falcon.crowdstrike.com_falconcontainers.yaml
-	(echo "---"; cat $^ ) > $@
+	(echo "---"; sed -n '/^status:/q;p' $^ ) > $@
+
 deploy/parts/crd-falconnodesensors.yaml: bundle/manifests/falcon.crowdstrike.com_falconnodesensors.yaml
-	(echo "---"; cat $^ ) > $@
+	(echo "---"; sed -n '/^status:/q;p' $^ ) > $@
 
 deploy/falcon-operator.yaml: deploy/parts/ns.yaml deploy/parts/crd-falconcontainers.yaml deploy/parts/crd-falconnodesensors.yaml deploy/parts/role.yaml deploy/parts/service_account.yaml deploy/parts/role_binding.yaml deploy/parts/operator.yaml
 	cat $^ > $@

--- a/deploy/falcon-operator.yaml
+++ b/deploy/falcon-operator.yaml
@@ -1916,12 +1916,6 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null
-  storedVersions: null
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -2309,12 +2303,6 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null
-  storedVersions: null
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole


### PR DESCRIPTION
A following error has been registered through terraform:

```
│ Error: Forbidden attribute key in "manifest" value │
│   with module.falcon-operator.kubernetes_manifest.test["/apis/apiextensions.k8s.io/v1/customresourcedefinitions/falconcontainers.falcon.crowdstrike.com"],
│   on .terraform/modules/falcon-operator/manifest.tf line 11, in resource "kubernetes_manifest" "test":
│   11: resource "kubernetes_manifest" "test" {
│
│ 'status' attribute key is not allowed in manifest configuration
```

/cc @ffalor 
