### PR TITLE
Moved all backend config references from Node to Falcon parent

### DIFF
--- a/apis/falcon/v1alpha1/falcon_api.go
+++ b/apis/falcon/v1alpha1/falcon_api.go
@@ -62,6 +62,11 @@ type FalconSensor struct {
 	// +kubebuilder:default:=none
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Trace Level",order=7
 	Trace string `json:"trace,omitempty"`
+	// Sets the backend to be used by the DaemonSet Sensor.
+	// +kubebuilder:default=kernel
+	// +kubebuilder:validation:Enum=kernel;bpf
+	// +operator-sdk-csv:customresourcedefinitions:type=spec,order=8
+	Backend string `json:"backend,omitempty"`
 }
 
 // RegistryTLSSpec configures TLS for registry pushing

--- a/apis/falcon/v1alpha1/falconnodesensor_types.go
+++ b/apis/falcon/v1alpha1/falconnodesensor_types.go
@@ -81,11 +81,6 @@ type FalconNodeSensorConfig struct {
 	// +kubebuilder:default=false
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,order=7
 	NodeCleanup *bool `json:"disableCleanup,omitempty"`
-	// Sets the backend to be used by the DaemonSet Sensor.
-	// +kubebuilder:default=kernel
-	// +kubebuilder:validation:Enum=kernel;bpf
-	// +operator-sdk-csv:customresourcedefinitions:type=spec,order=8
-	Backend string `json:"backend,omitempty"`
 
 	// Version of the sensor to be installed. The latest version will be selected when this version specifier is missing.
 	Version *string `json:"version,omitempty"`

--- a/bundle/manifests/falcon.crowdstrike.com_falconnodesensors.yaml
+++ b/bundle/manifests/falcon.crowdstrike.com_falconnodesensors.yaml
@@ -68,6 +68,13 @@ spec:
                     description: Falcon Customer ID (CID)
                     pattern: ^[0-9a-fA-F]{32}-[0-9a-fA-F]{2}$
                     type: string
+                  backend:
+                    default: kernel
+                    description: Sets the backend to be used by the DaemonSet Sensor.
+                    enum:
+                    - kernel
+                    - bpf
+                    type: string
                   provisioning_token:
                     description: Installation token that prevents unauthorized hosts
                       from being accidentally or maliciously added to your customer
@@ -128,13 +135,6 @@ spec:
               node:
                 description: Various configuration for DaemonSet Deployment
                 properties:
-                  backend:
-                    default: kernel
-                    description: Sets the backend to be used by the DaemonSet Sensor.
-                    enum:
-                    - kernel
-                    - bpf
-                    type: string
                   disableCleanup:
                     default: false
                     description: Disables the cleanup of the sensor through DaemonSet

--- a/config/crd/bases/falcon.crowdstrike.com_falconnodesensors.yaml
+++ b/config/crd/bases/falcon.crowdstrike.com_falconnodesensors.yaml
@@ -69,6 +69,13 @@ spec:
                     description: Falcon Customer ID (CID)
                     pattern: ^[0-9a-fA-F]{32}-[0-9a-fA-F]{2}$
                     type: string
+                  backend:
+                    default: kernel
+                    description: Sets the backend to be used by the DaemonSet Sensor.
+                    enum:
+                    - kernel
+                    - bpf
+                    type: string
                   provisioning_token:
                     description: Installation token that prevents unauthorized hosts
                       from being accidentally or maliciously added to your customer
@@ -129,13 +136,6 @@ spec:
               node:
                 description: Various configuration for DaemonSet Deployment
                 properties:
-                  backend:
-                    default: kernel
-                    description: Sets the backend to be used by the DaemonSet Sensor.
-                    enum:
-                    - kernel
-                    - bpf
-                    type: string
                   disableCleanup:
                     default: false
                     description: Disables the cleanup of the sensor through DaemonSet

--- a/config/samples/falcon_v1alpha1_falconnodesensor-all-options.yaml
+++ b/config/samples/falcon_v1alpha1_falconnodesensor-all-options.yaml
@@ -15,7 +15,6 @@ spec:
     cid: 00001111222233334444555566667777-12
   node:
     # Use to not need falcon_api section above
-    backend: kernel
     image_override: repo.host.com:4000/name:tag
     imagePullPolicy: Always
     # secret within the falcon-system namespace.
@@ -41,6 +40,7 @@ spec:
     app: 8080
     billing: metered
     # Use to not need falcon_api section above
+    backend: kernel
     provisioning_token: 00001111
     cid: 00001111222233334444555566667777-12
     tags:

--- a/deploy/falcon-operator.yaml
+++ b/deploy/falcon-operator.yaml
@@ -1993,6 +1993,13 @@ spec:
                     description: Falcon Customer ID (CID)
                     pattern: ^[0-9a-fA-F]{32}-[0-9a-fA-F]{2}$
                     type: string
+                  backend:
+                    default: kernel
+                    description: Sets the backend to be used by the DaemonSet Sensor.
+                    enum:
+                    - kernel
+                    - bpf
+                    type: string
                   provisioning_token:
                     description: Installation token that prevents unauthorized hosts
                       from being accidentally or maliciously added to your customer
@@ -2053,13 +2060,6 @@ spec:
               node:
                 description: Various configuration for DaemonSet Deployment
                 properties:
-                  backend:
-                    default: kernel
-                    description: Sets the backend to be used by the DaemonSet Sensor.
-                    enum:
-                    - kernel
-                    - bpf
-                    type: string
                   disableCleanup:
                     default: false
                     description: Disables the cleanup of the sensor through DaemonSet

--- a/docs/node/README.md
+++ b/docs/node/README.md
@@ -34,6 +34,7 @@ spec:
 | falcon_api.client_secret            | (optional) CrowdStrike API Client Secret                                                                                                  |
 | falcon_api.client_region            | (optional) CrowdStrike cloud region (allowed values: autodiscover, us-1, us-2, eu-1, us-gov-1)                                            |
 | falcon.cid                          | (optional) CrowdStrike Falcon CID override                                                                                                |
+| falcon.backend                        | (optional) Configure the backend mode for Falcon Sensor (allowed values: kernel, bpf)                                                     |
 | falcon.apd                                | (optional) Configure Falcon Sensor to leverage a proxy host                                                                                                                                                             |
 | falcon.aph                                | (optional) Configure the host Falcon Sensor should leverage for proxying                                                                                                                                                |
 | falcon.app                                | (optional) Configure the port Falcon Sensor should leverage for proxying                                                                                                                                                |
@@ -43,7 +44,6 @@ spec:
 | falcon.trace                              | (optional) Configure Falcon Sensor Trace Logging Level (none, err, warn, info, debug)                                                                                                                                   |
 | node.image_override                 | (optional) Location of the Falcon Sensor Image. Specify only when you mirror the original image to your own image repository              |
 | node.imagePullSecrets               | (optional) list of references to secrets in the falcon-system namespace to use for pulling image from image_override location.            |
-| node.backend                        | (optional) Configure the backend mode for Falcon Sensor (allowed values: kernel, bpf)                                                     |
 | node.disableCleanup                 | (optional) Cleans up `/opt/CrowdStrike` on the nodes by deleting the files and directory.                                                 |
 | node.version                        | (optional) Enforce particular Falcon Sensor version to be installed (example: "6.35", "6.35.0-13207")                                     |
 

--- a/pkg/node/config_cache.go
+++ b/pkg/node/config_cache.go
@@ -52,8 +52,8 @@ func (cc *ConfigCache) SensorEnvVars() map[string]string {
 	if cc.cid != "" {
 		sensorConfig["FALCONCTL_OPT_CID"] = cc.cid
 	}
-	if cc.nodesensor.Spec.Node.Backend != "" {
-		sensorConfig["FALCONCTL_OPT_BACKEND"] = cc.nodesensor.Spec.Node.Backend
+	if cc.nodesensor.Spec.Falcon.Backend != "" {
+		sensorConfig["FALCONCTL_OPT_BACKEND"] = cc.nodesensor.Spec.Falcon.Backend
 	}
 	return sensorConfig
 }


### PR DESCRIPTION
Helm: uses falcon.backed as seen [here](https://github.com/CrowdStrike/falcon-helm/blob/main/helm-charts/falcon-sensor/values.yaml).
Operator: uses node.backend as seen [here](https://github.com/CrowdStrike/falcon-operator/blob/main/deploy/falcon-operator.yaml).

moving all backend references under Falcon
