### PR TITLE
fix: exclude gosec rule G307 as it has been removed in the upstream branch

### DIFF
--- a/.github/workflows/gosec.yml
+++ b/.github/workflows/gosec.yml
@@ -27,4 +27,4 @@ jobs:
     - name: Run Gosec Security Scanner
       uses: securego/gosec@master
       with:
-        args: ./...
+        args: '-exclude=G307 ./...'


### PR DESCRIPTION
Since this rule has been removed in the gosec master branch, this will disable the rule in the scan. We can remove this when there is a new gosec release.