### PR TITLE
node: updating init containers for node daemonset and node cleanup da…

### DIFF
--- a/pkg/common/common_test.go
+++ b/pkg/common/common_test.go
@@ -14,14 +14,14 @@ type FakeDiscovery struct {
 }
 
 func TestInitContainerArgs(t *testing.T) {
-	want := []string{"-c", `if [ -d "/opt/CrowdStrike/falconstore" ] ; then echo "Re-creating /opt/CrowdStrike/falconstore as it is a directory instead of a file"; rm -rf /opt/CrowdStrike/falconstore; fi; mkdir -p /opt/CrowdStrike && touch /opt/CrowdStrike/falconstore`}
+	want := []string{"-c", `if [ -x "/opt/CrowdStrike/falcon-daemonset-init" ]; then echo "Executing falcon-daemonset-init -i"; falcon-daemonset-init -i ; else if [ -d "/host_opt/CrowdStrike/falconstore" ]; then echo "Re-creating /opt/CrowdStrike/falconstore as it is a directory instead of a file"; rm -rf /host_opt/CrowdStrike/falconstore; fi; mkdir -p /host_opt/CrowdStrike/ && touch /host_opt/CrowdStrike/falconstore; fi`}
 	if got := InitContainerArgs(); !reflect.DeepEqual(got, want) {
 		t.Errorf("InitContainerArgs() = %v, want %v", got, want)
 	}
 }
 
 func TestInitCleanupArgs(t *testing.T) {
-	want := []string{"-c", "rm -rf /opt/CrowdStrike"}
+	want := []string{"-c", `if [ -x "/opt/CrowdStrike/falcon-daemonset-init" ]; then echo "Running falcon-daemonset-init -u"; falcon-daemonset-init -u; else echo "Manually removing /opt/CrowdStrike"; rm -rf /opt/CrowdStrike; fi`}
 	if got := InitCleanupArgs(); !reflect.DeepEqual(got, want) {
 		t.Errorf("InitCleanupArgs() = %v, want %v", got, want)
 	}

--- a/pkg/common/common_test.go
+++ b/pkg/common/common_test.go
@@ -21,7 +21,7 @@ func TestInitContainerArgs(t *testing.T) {
 }
 
 func TestInitCleanupArgs(t *testing.T) {
-	want := []string{"-c", `if [ -x "/opt/CrowdStrike/falcon-daemonset-init" ]; then echo "Running falcon-daemonset-init -u"; falcon-daemonset-init -u; else echo "Manually removing /host_opt/CrowdStrike"; rm -rf /host_opt/CrowdStrike; fi`}
+	want := []string{"-c", `if [ -x "/opt/CrowdStrike/falcon-daemonset-init" ]; then echo "Running falcon-daemonset-init -u"; falcon-daemonset-init -u; else echo "Manually removing /host_opt/CrowdStrike/"; rm -rf /host_opt/CrowdStrike/; fi`}
 	if got := InitCleanupArgs(); !reflect.DeepEqual(got, want) {
 		t.Errorf("InitCleanupArgs() = %v, want %v", got, want)
 	}

--- a/pkg/common/common_test.go
+++ b/pkg/common/common_test.go
@@ -21,7 +21,7 @@ func TestInitContainerArgs(t *testing.T) {
 }
 
 func TestInitCleanupArgs(t *testing.T) {
-	want := []string{"-c", `if [ -x "/opt/CrowdStrike/falcon-daemonset-init" ]; then echo "Running falcon-daemonset-init -u"; falcon-daemonset-init -u; else echo "Manually removing /opt/CrowdStrike"; rm -rf /opt/CrowdStrike; fi`}
+	want := []string{"-c", `if [ -x "/opt/CrowdStrike/falcon-daemonset-init" ]; then echo "Running falcon-daemonset-init -u"; falcon-daemonset-init -u; else echo "Manually removing /host_opt/CrowdStrike"; rm -rf /host_opt/CrowdStrike; fi`}
 	if got := InitCleanupArgs(); !reflect.DeepEqual(got, want) {
 		t.Errorf("InitCleanupArgs() = %v, want %v", got, want)
 	}

--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -1,14 +1,20 @@
 package common
 
 const (
-	FalconContainerInjection       = "sensor.falcon-system.crowdstrike.com/injection"
-	FalconContainerInjectorTLSName = "injector-tls"
-	FalconHostInstallDir           = "/opt"
-	FalconDataDir                  = "/opt/CrowdStrike"
-	FalconStoreFile                = "/opt/CrowdStrike/falconstore"
-	FalconContainerProbePath       = "/live"
-	FalconServiceHTTPSName         = "https"
-	FalconServiceHTTPSPort         = 443
+	FalconContainerInjection               = "sensor.falcon-system.crowdstrike.com/injection"
+	FalconContainerInjectorTLSName         = "injector-tls"
+	FalconHostInstallDir                   = "/opt"
+	FalconInitHostInstallDir               = "/host_opt"
+	FalconDataDir                          = "/opt/CrowdStrike"
+	FalconInitDataDir                      = "/host_opt/CrowdStrike/"
+	FalconStoreFile                        = "/opt/CrowdStrike/falconstore"
+	FalconInitStoreFile                    = "/host_opt/CrowdStrike/falconstore"
+	FalconDaemonsetInitBinary              = "/opt/CrowdStrike/falcon-daemonset-init"
+	FalconDaemonsetInitBinaryInvocation    = "falcon-daemonset-init -i"
+	FalconDaemonsetCleanupBinaryInvocation = "falcon-daemonset-init -u"
+	FalconContainerProbePath               = "/live"
+	FalconServiceHTTPSName                 = "https"
+	FalconServiceHTTPSPort                 = 443
 
 	FalconInstanceNameKey = "crowdstrike.com/name"
 	FalconInstanceKey     = "crowdstrike.com/instance"

--- a/pkg/common/funcs.go
+++ b/pkg/common/funcs.go
@@ -33,8 +33,8 @@ func InitCleanupArgs() []string {
 		// Versions of falcon-sensor 6.53+ will contain an init binary that we invoke with a cleanup argument
 		`if [ -x "` + FalconDaemonsetInitBinary + `" ]; then ` +
 			`echo "Running ` + FalconDaemonsetCleanupBinaryInvocation + `"; ` + FalconDaemonsetCleanupBinaryInvocation + `; else ` +
-			`echo "Manually removing ` + FalconDataDir + `"; ` +
-			`rm -rf ` + FalconDataDir +
+			`echo "Manually removing ` + FalconInitDataDir + `"; ` +
+			`rm -rf ` + FalconInitDataDir +
 			`; fi`,
 	}
 }

--- a/pkg/common/funcs.go
+++ b/pkg/common/funcs.go
@@ -16,17 +16,26 @@ import (
 func InitContainerArgs() []string {
 	return []string{
 		"-c",
-		`if [ -d "/opt/CrowdStrike/falconstore" ] ; then echo "Re-creating /opt/CrowdStrike/falconstore as it is a directory instead of a file"; rm -rf /opt/CrowdStrike/falconstore; fi; ` +
-			"mkdir -p " + FalconDataDir +
-			" && " +
-			"touch " + FalconStoreFile,
+		// Versions of falcon-sensor 6.53+ will contain an init binary that we invoke
+		`if [ -x "` + FalconDaemonsetInitBinary + `" ]; then ` +
+			`echo "Executing ` + FalconDaemonsetInitBinaryInvocation + `"; ` + FalconDaemonsetInitBinaryInvocation + ` ; else ` +
+			`if [ -d "` + FalconInitStoreFile + `" ]; then echo "Re-creating ` + FalconStoreFile + ` as it is a directory instead of a file"; rm -rf ` + FalconInitStoreFile + `; fi; ` +
+			`mkdir -p ` + FalconInitDataDir +
+			` && ` +
+			`touch ` + FalconInitStoreFile +
+			`; fi`,
 	}
 }
 
 func InitCleanupArgs() []string {
 	return []string{
 		"-c",
-		"rm -rf " + FalconDataDir,
+		// Versions of falcon-sensor 6.53+ will contain an init binary that we invoke with a cleanup argument
+		`if [ -x "` + FalconDaemonsetInitBinary + `" ]; then ` +
+			`echo "Running ` + FalconDaemonsetCleanupBinaryInvocation + `"; ` + FalconDaemonsetCleanupBinaryInvocation + `; else ` +
+			`echo "Manually removing ` + FalconDataDir + `"; ` +
+			`rm -rf ` + FalconDataDir +
+			`; fi`,
 	}
 }
 

--- a/pkg/node/assets/daemonset.go
+++ b/pkg/node/assets/daemonset.go
@@ -194,6 +194,9 @@ func RemoveNodeDirDaemonset(dsName, image, serviceAccount string, node *falconv1
 	privileged := true
 	escalation := true
 	readOnlyFs := false
+	hostpid := true
+	hostnetwork := true
+	hostipc := true
 	runAs := int64(0)
 
 	return &appsv1.DaemonSet{
@@ -241,6 +244,9 @@ func RemoveNodeDirDaemonset(dsName, image, serviceAccount string, node *falconv1
 					// NodeSelector is set to linux until windows containers are supported for the Falcon sensor
 					NodeSelector:                  common.NodeSelector,
 					Tolerations:                   node.Spec.Node.Tolerations,
+					HostPID:                       hostpid,
+					HostIPC:                       hostipc,
+					HostNetwork:                   hostnetwork,
 					TerminationGracePeriodSeconds: getTermGracePeriod(node),
 					ImagePullSecrets:              pullSecrets(node),
 					InitContainers: []corev1.Container{
@@ -258,7 +264,7 @@ func RemoveNodeDirDaemonset(dsName, image, serviceAccount string, node *falconv1
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      "opt-crowdstrike",
-									MountPath: common.FalconHostInstallDir,
+									MountPath: common.FalconInitHostInstallDir,
 								},
 							},
 						},

--- a/pkg/node/assets/daemonset.go
+++ b/pkg/node/assets/daemonset.go
@@ -195,8 +195,6 @@ func RemoveNodeDirDaemonset(dsName, image, serviceAccount string, node *falconv1
 	escalation := true
 	readOnlyFs := false
 	hostpid := true
-	hostnetwork := true
-	hostipc := true
 	runAs := int64(0)
 
 	return &appsv1.DaemonSet{
@@ -245,8 +243,6 @@ func RemoveNodeDirDaemonset(dsName, image, serviceAccount string, node *falconv1
 					NodeSelector:                  common.NodeSelector,
 					Tolerations:                   node.Spec.Node.Tolerations,
 					HostPID:                       hostpid,
-					HostIPC:                       hostipc,
-					HostNetwork:                   hostnetwork,
 					TerminationGracePeriodSeconds: getTermGracePeriod(node),
 					ImagePullSecrets:              pullSecrets(node),
 					InitContainers: []corev1.Container{

--- a/pkg/node/assets/daemonset.go
+++ b/pkg/node/assets/daemonset.go
@@ -124,8 +124,14 @@ func Daemonset(dsName, image, serviceAccount string, node *falconv1alpha1.Falcon
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      "falconstore-hostdir",
-									MountPath: common.FalconHostInstallDir,
+									MountPath: common.FalconInitHostInstallDir,
 								},
+							},
+							SecurityContext: &corev1.SecurityContext{
+								Privileged:               &privileged,
+								RunAsUser:                &runAs,
+								ReadOnlyRootFilesystem:   &readOnlyFs,
+								AllowPrivilegeEscalation: &escalation,
 							},
 						},
 					},

--- a/pkg/node/assets/daemonset_test.go
+++ b/pkg/node/assets/daemonset_test.go
@@ -237,8 +237,6 @@ func TestRemoveNodeDirDaemonset(t *testing.T) {
 	escalation := true
 	readOnlyFs := false
 	hostpid := true
-	hostnetwork := true
-	hostipc := true
 	runAs := int64(0)
 
 	want := &appsv1.DaemonSet{
@@ -285,8 +283,6 @@ func TestRemoveNodeDirDaemonset(t *testing.T) {
 					NodeSelector:                  common.NodeSelector,
 					Tolerations:                   falconNode.Spec.Node.Tolerations,
 					HostPID:                       hostpid,
-					HostIPC:                       hostipc,
-					HostNetwork:                   hostnetwork,
 					TerminationGracePeriodSeconds: getTermGracePeriod(&falconNode),
 					ImagePullSecrets:              pullSecrets(&falconNode),
 					InitContainers: []corev1.Container{

--- a/pkg/node/assets/daemonset_test.go
+++ b/pkg/node/assets/daemonset_test.go
@@ -236,6 +236,9 @@ func TestRemoveNodeDirDaemonset(t *testing.T) {
 	privileged := true
 	escalation := true
 	readOnlyFs := false
+	hostpid := true
+	hostnetwork := true
+	hostipc := true
 	runAs := int64(0)
 
 	want := &appsv1.DaemonSet{
@@ -281,6 +284,9 @@ func TestRemoveNodeDirDaemonset(t *testing.T) {
 					// NodeSelector is set to linux until windows containers are supported for the Falcon sensor
 					NodeSelector:                  common.NodeSelector,
 					Tolerations:                   falconNode.Spec.Node.Tolerations,
+					HostPID:                       hostpid,
+					HostIPC:                       hostipc,
+					HostNetwork:                   hostnetwork,
 					TerminationGracePeriodSeconds: getTermGracePeriod(&falconNode),
 					ImagePullSecrets:              pullSecrets(&falconNode),
 					InitContainers: []corev1.Container{
@@ -298,7 +304,7 @@ func TestRemoveNodeDirDaemonset(t *testing.T) {
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      "opt-crowdstrike",
-									MountPath: common.FalconHostInstallDir,
+									MountPath: common.FalconInitHostInstallDir,
 								},
 							},
 						},

--- a/pkg/node/assets/daemonset_test.go
+++ b/pkg/node/assets/daemonset_test.go
@@ -152,10 +152,16 @@ func TestDaemonset(t *testing.T) {
 							Image:   image,
 							Command: common.FalconShellCommand,
 							Args:    common.InitContainerArgs(),
+							SecurityContext: &corev1.SecurityContext{
+								Privileged:               &privileged,
+								RunAsUser:                &runAs,
+								ReadOnlyRootFilesystem:   &readOnlyFs,
+								AllowPrivilegeEscalation: &escalation,
+							},
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      "falconstore-hostdir",
-									MountPath: common.FalconHostInstallDir,
+									MountPath: common.FalconInitHostInstallDir,
 								},
 							},
 						},


### PR DESCRIPTION
…emonset

Versions 6.53+ of the KMSD sensor image contain a falcon-daemonset-init binary, which is used to initialize `falconstore` while accounting for limitations imposed by some operating systems/environments.

Ready for review; please allow me to self-merge once approved.