### PR TITLE
OpenShift prescriptive docs

### DIFF
--- a/docs/deployment/openshift/README-container.md
+++ b/docs/deployment/openshift/README-container.md
@@ -1,0 +1,29 @@
+# Deployment Guide for OpenShift (FalconContainer)
+
+> [!NOTE]
+> This guide is for rare cases where you need to deploy the FalconContainer sidecar-based sensor. The method does not protect the CoreOS host so is not recommended. Unless you are sure you need this, use the [FalconNodeSensor deployment guide](README.md) instead.
+
+## Prerequisites
+
+Refer to the [standard deployment guide](README.md):
+
+1. Follow prerequisites listed there
+2. Follow the section _Install the operator_
+
+## Deploy the sensor
+
+### Option 1: Via the web console
+
+- To deploy the Falon Sidecar Sensor, click `Create Instance` for the `Falcon Container` Kind under the `Provided APIs` for the Falcon Operator.
+
+   ![OpenShift CrowdStrike Falcon Sidecar Sensor](images/ocp-fcs.png)
+
+-  Enter your API client ID and secret under `Falcon Platform API Configuration`, then click `Create`.
+
+   ![OpenShift CrowdStrike Falcon Sidecar Sensor](images/ocp-fcsinstall.png)
+
+### Option 2: Via manifest files
+
+- Deploy FalconContainer using the `oc` command, supplying your API client ID and secret in `spec.falcon_api.client_id` and `client_secret`:
+  ```
+  oc create -f https://raw.githubusercontent.com/CrowdStrike/falcon-operator/main/docs/deployment/openshift/falconcontainer.yaml --edit=true

--- a/docs/deployment/openshift/README-container.md
+++ b/docs/deployment/openshift/README-container.md
@@ -3,6 +3,8 @@
 > [!NOTE]
 > This guide is for rare cases where you need to deploy the FalconContainer sidecar-based sensor. The method does not protect the CoreOS host so is not recommended. Unless you are sure you need this, use the [FalconNodeSensor deployment guide](README.md) instead.
 
+This guide assumes the default configuration for the sensor is sufficient. For all configuration options, see [FalconContainer](resources/container/README.md).
+
 ## Prerequisites
 
 Refer to the [FalconNodeSensor deployment guide](README.md):

--- a/docs/deployment/openshift/README.md
+++ b/docs/deployment/openshift/README.md
@@ -2,29 +2,38 @@
 
 This document guides you through the recommended installation of the CrowdStrike Falcon agent on OpenShift, including self-managed OpenShift and OpenShift cloud services. This approach enables CrowdStrike's breach prevention on Red Hat Enterprise Linux CoreOS (the operating system that powers OpenShift), as well as all container workloads running on top of it. Control plane and worker nodes are both protected by default.
 
-The Falcon agent is deployed as a certified operating in OpenShift's OperatorHub. This guide documents installation in three forms:
+The Falcon agent is deployed as a certified operator in OpenShift's OperatorHub. This guide documents installation in three forms:
 
-- Via the web console -- For quick evaluations.
-- Via the command line -- For quick evaluations and script-based configuration management workflows.
-- Via manifest files -- For configuration-as-code and GitOps approaches to security. Recommended for production deployments to ensure consistency and reproducibility.
+- Via the web console, for quick evaluations.
+- Via the command line, for quick evaluations and script-based configuration management workflows.
+- Via manifest files, for configuration-as-code and GitOps approaches to security. Recommended for production deployments to ensure consistency and reproducibility.
 
 You only need to follow one installation method per section.
-
-The operator provides two custom resources which provide alternative installation options:
-
-- **FalconNodeSensor** (recommended) installs the Falcon Linux sensor as a kernel module on all CoreOS nodes. Protects all hosts and all containers, and has minimal performance impact.
-- **FalconContainer** injects the Falcon sensor into every pod as a sidecar container. Does not protect the host and introduces overhead per pod, but can be installed privileged access.
-
-This guide only covers deployment of the FalconNodeSensor, which is the recommended deployment method for OpenShift. In very rare circumstances where you cannot deploy the FalconNodeSensor, refer to the [FalconContainer deployment guide](README-container.md). This guide also covers only the default installation options, which are sufficient for most deployments. For a list of all configuration options, see [FalconNodeSensor](resources/node/README.md) or [FalconContainer](resources/container/README.md).
 
 ## Prerequisites
 
 - A Falcon Cloud Security for Containers subscription (previously known as Cloud Workload Protection)
-- Red Hat Openshift 4.10+ with `cluster-admin` privileges
+- Red Hat Openshift 4.10+ with `cluster-admin` privileges:
   - Self-managed OpenShift on any platform
   - Red Hat OpenShift Service on AWS (ROSA)
   - Azure Red Hat OpenShift (ARO)
   - Red Hat OpenShift on IBM Cloud (RHOIC)
+
+## Limitations
+
+This guide covers deployment of the FalconNodeSensor custom resource, which is the recommended deployment method for OpenShift because it provides protection for both CoreOS and all container workloads. In very rare circumstances where you cannot deploy the FalconNodeSensor, refer to the [FalconContainer deployment guide](README-container.md).
+
+This guide also covers only the default installation options, which are sufficient for most deployments. For a list of all configuration options, see [FalconNodeSensor](resources/node/README.md) or [FalconContainer](resources/container/README.md).
+
+## Overview
+
+The deployment process consists of three steps:
+
+1. In the Falcon platform, create a new API client with the "Falcon Images Download: Read" and "Sensor Download: Read" permissions. Note your client ID and secret.
+2. In OpenShift, install the Falcon operator (use the Marketplace operator).
+3. Once the Falcon operator is installed, create a FalconNodeSensor, and provide your new API client’s ID and secret.
+
+The Falcon agent will be deployed to all nodes in the cluster and immediately start providing protection, no reboots or redeploys needed. The following sections provide details on each of these steps.
 
 ## Create a Falcon API client
 
@@ -147,99 +156,4 @@ Once the operator has deployed, you can now deploy the FalconNodeSensor.
 - Deploy FalconNodeSensor using the `oc` command, supplying your API client ID and secret in `spec.falcon_api.client_id` and `client_secret`:
   ```
   oc create -n falcon-operator -f https://raw.githubusercontent.com/CrowdStrike/falcon-operator/main/config/samples/falcon_v1alpha1_falconnodesensor.yaml --edit=true
-  ```
-
-## Uninstalling
-
-When uninstalling the operator, it is important to make sure to uninstall the deployed custom resources first *before* you uninstall the operator.
-This will insure proper cleanup of the resources.
-
-### Uninstall using the Web Console (GUI)
-
-- To uninstall in the OpenShift Web Console (GUI), expand the `Operators` menu and click on `Installed Operators`.
-
-   ![OpenShift CrowdStrike Operator Uninstall](images/ocp-uninstall.png)
-
-#### Uninstall the Node Sensor
-
-- Click on the `CrowdStrike Falcon Platform - Operator` listing, followed by clicking on the `Falcon Node Sensor` tab.
-
-   ![OpenShift CrowdStrike Node Sensor Uninstall](images/ocp-nodetab.png)
-
-- On the deployed `FalconNodeSensor` Kind, click the 3 vertical dot action menu on the far right, and click `Delete FalconNodeSensor`.
-
-   ![OpenShift CrowdStrike Node Sensor Uninstall](images/ocp-nodedel.png)
-
-#### Uninstall the Sidecar Sensor
-
-- Click on the `CrowdStrike Falcon Platform - Operator` listing, followed by clicking on the `Falcon Container` tab.
-
-   ![OpenShift CrowdStrike Sidecar Uninstall](images/ocp-containertab.png)
-
-- On the deployed `FalconContainer` Kind, click the 3 vertical dot action menu on the far right, and click `Delete FalconContainer`.
-
-   ![OpenShift CrowdStrike Sidecar Uninstall](images/ocp-containerdel.png)
-
-#### Uninstall the Operator
-
-- In the list of `Installed Operators`, click the 3 vertical dot action menu on the far right of the `CrowdStrike Falcon Platform - Operator` listing, and click `Uninstall Operator`.
-
-   ![OpenShift CrowdStrike Operator Uninstall](images/ocp-uninstall2.png)
-
-  This will open an uninstall confirmation box, click `Uninstall` to complete the uninstall.
-
-### Uninstall using the CLI
-
-#### Uninstall using the Krew plugin (Preferred)
-
-To easily uninstall the operator, install Krew if it is not already installed:
-
-1. Install Krew. See https://krew.sigs.k8s.io/docs/user-guide/setup/install/
-2. Verify install with `oc krew`
-3. Update krew `oc krew update`
-4. Install the operator krew plugin `oc krew install operator`
-
-Once the Krew plugin is installed:
-
-1. Using the krew plugin, uninstall the certified operator if it is already installed with
-   ```
-   oc operator uninstall falcon-operator-rhmp -n falcon-operator -X
-   ```
-
-#### Uninstall using the Subscription/CSV method
-
-##### Uninstall the Node Sensor
-
-- To uninstall the node sensor, simply remove the FalconNodeSensor resource.
-  ```
-  oc delete falconnodesensor -A --all
-  ```
-
-##### Uninstall the Sidecar Sensor
-
-- To uninstall Falcon Container simply remove FalconContainer resource. The operator will uninstall Falcon Container product from the cluster.
-  ```
-  oc delete falconcontainers.falcon.crowdstrike.com default
-  ```
-
-##### Uninstall the Operator
-
-- To uninstall Falcon Operator, get the name of the subscription that the operator was installed with:
-  ```
-  oc get sub -n falcon-operator
-  ```
-
-- Remove the subscription for the operator:
-  ```
-  oc delete sub falcon-operator -n falcon-operator
-  ```
-
-- Get the name of the ClusterServiceVersion for the operator.
-  ```
-  oc get csv -n falcon-operator
-  ```
-
-- Remove the ClusterServiceVersion for the operator. In this example, version 0.8.0 will be removed:
-  ```
-  oc delete csv falcon-operator.v0.8.0 -n falcon-operator
   ```

--- a/docs/deployment/openshift/README.md
+++ b/docs/deployment/openshift/README.md
@@ -13,7 +13,7 @@ You only need to follow one installation method per section.
 ## Prerequisites
 
 - A Falcon Cloud Security for Containers subscription (previously known as Cloud Workload Protection)
-- Red Hat Openshift 4.10+ with `cluster-admin` privileges:
+- Red Hat Openshift 4 with `cluster-admin` privileges:
   - Self-managed OpenShift on any platform
   - Red Hat OpenShift Service on AWS (ROSA)
   - Azure Red Hat OpenShift (ARO)
@@ -39,7 +39,8 @@ The Falcon agent will be deployed to all nodes in the cluster and immediately st
 
 To discover your customer ID and download the sensor image, the operator will connect to the Falcon API. You'll need to provide the API client ID and secret to the operator.
 
-1. Navigate to _API clients and keys_ ([US-1](https://falcon.crowdstrike.com/api-clients-and-keys/clients), [US-2](https://falcon.us-2.crowdstrike.com/api-clients-and-keys/clients)).
+1. Log in to the Falcon console.
+1. Navigate to _API clients and keys_.
 1. Click `Create API client`.
 1. Provide a name and description and the following permissions:
    - Falcon Images Download: Read
@@ -123,14 +124,14 @@ Installing the operator via manifest files allows you to check these files into 
   # falcon-operator-rhmp                               Red Hat Marketplace   18h
   ```
 
-- Create an `OperatorGroup` to allow the operator to be installed in the `falcon-operator` namespace (you can [review operatorgroup.yaml](operatorgroup.yaml)):
+- Create an `OperatorGroup` to allow the operator to be installed in the `falcon-operator` namespace:
   ```
-  oc create -f https://raw.githubusercontent.com/CrowdStrike/falcon-operator/main/docs/deployment/openshift/operatorgroup.yaml
+  oc create --edit=true -f https://raw.githubusercontent.com/CrowdStrike/falcon-operator/main/docs/deployment/openshift/operatorgroup.yaml
   ```
 
-- Create a `Subscription` to install the operator (you can [review redhat-subscription.yaml](redhat-subscription.yaml)):
+- Create a `Subscription` to install the operator:
   ```
-  oc create -f https://raw.githubusercontent.com/CrowdStrike/falcon-operator/main/docs/deployment/openshift/redhat-subscription.yaml
+  oc create --edit=true -f https://raw.githubusercontent.com/CrowdStrike/falcon-operator/main/docs/deployment/openshift/redhat-subscription.yaml
   ```
 
 ## Deploy the sensor
@@ -153,7 +154,11 @@ Deploying the Falcon sensors via the CLI and with manifest files are the same pr
 
 Once the operator has deployed, you can now deploy the FalconNodeSensor.
 
-- Deploy FalconNodeSensor using the `oc` command, supplying your API client ID and secret in `spec.falcon_api.client_id` and `client_secret`:
+- Deploy FalconNodeSensor to the `falcon-operator` namespace using the `oc` command, supplying your API client ID and secret in `spec.falcon_api.client_id` and `client_secret` (if you want deploy the node sensor to a different namespace, see [Deploying the node sensor to a custom namespace](custom-namespace.md)):
   ```
   oc create -n falcon-operator -f https://raw.githubusercontent.com/CrowdStrike/falcon-operator/main/config/samples/falcon_v1alpha1_falconnodesensor.yaml --edit=true
   ```
+
+## Uninstall the operator
+
+See [Uninstalling the operator](uninstall.md).

--- a/docs/deployment/openshift/custom-namespace.md
+++ b/docs/deployment/openshift/custom-namespace.md
@@ -1,0 +1,24 @@
+# Deploying the Node Sensor to a custom Namespace
+
+If desired, the FalconNodeSensor can be deployed to a namespace of your choosing instead of deploying to the operator namespace.
+To deploy to a custom namespace (replacing `my-special-namespace` as desired):
+
+- Create a new project
+  ```
+  oc new-project my-special-namespace
+  ```
+
+- Create the service account in the new namespace
+  ```
+  oc create sa falcon-operator-node-sensor -n my-special-namespace
+  ```
+
+- Add the service account to the privileged SCC
+  ```
+  oc adm policy add-scc-to-user privileged system:serviceaccount:my-special-namespace:falcon-operator-node-sensor
+  ```
+
+- Deploy FalconNodeSensor to the custom namespace:
+  ```
+  oc create -n my-special-namespace -f https://raw.githubusercontent.com/CrowdStrike/falcon-operator/main/docs/config/samples/falcon_v1alpha1_falconnodesensor.yaml --edit=true
+  ```

--- a/docs/deployment/openshift/custom-namespace.md
+++ b/docs/deployment/openshift/custom-namespace.md
@@ -1,11 +1,17 @@
-# Deploying the Node Sensor to a custom Namespace
+# Deploying the node sensor to a custom namespace
 
 If desired, the FalconNodeSensor can be deployed to a namespace of your choosing instead of deploying to the operator namespace.
+
 To deploy to a custom namespace (replacing `my-special-namespace` as desired):
 
 - Create a new project
   ```
   oc new-project my-special-namespace
+  ```
+
+- Modify the `OperatorGroup` to include the custom namespace in `spec.targetNamespaces`
+  ```
+  oc edit -n falcon-operator operatorgroup
   ```
 
 - Create the service account in the new namespace

--- a/docs/deployment/openshift/deploy-container-sensor.md
+++ b/docs/deployment/openshift/deploy-container-sensor.md
@@ -5,7 +5,7 @@
 
 ## Prerequisites
 
-Refer to the [standard deployment guide](README.md):
+Refer to the [FalconNodeSensor deployment guide](README.md):
 
 1. Follow prerequisites listed there
 2. Follow the section _Install the operator_

--- a/docs/deployment/openshift/operatorgroup.yaml
+++ b/docs/deployment/openshift/operatorgroup.yaml
@@ -4,5 +4,7 @@ metadata:
   name: falcon-operator
   namespace: falcon-operator
 spec:
+  # targetNamespaces contains the namespace where you will install the node sensor, i.e. where you
+  # will create the FalconNodeSensor resource. By default we use the same namespace as the operator.
   targetNamespaces:
   - falcon-operator

--- a/docs/deployment/openshift/operatorgroup.yaml
+++ b/docs/deployment/openshift/operatorgroup.yaml
@@ -5,4 +5,4 @@ metadata:
   namespace: falcon-operator
 spec:
   targetNamespaces:
-  - MYNAMESPACE
+  - falcon-operator

--- a/docs/deployment/openshift/redhat-subscription.yaml
+++ b/docs/deployment/openshift/redhat-subscription.yaml
@@ -7,3 +7,7 @@ spec:
   name: falcon-operator-rhmp
   source: redhat-marketplace
   sourceNamespace: openshift-marketplace
+  ### To install a specific version of the operator, specify a startingCSV. You can see available versions with:
+  ###   oc get packagemanifests falcon-operator-rhmp -n openshift-marketplace -o jsonpath='{range .status.channels[*]}Channel: {.name}{"\n"}{range .entries[*]} - Version: {.name}{"\n"}{end}{end}{"\nDefault Channel: "}{.status.defaultChannel}{"\n"}'
+  ### You may also need to modify `channel` to match.
+  # startingCSV: falcon-operator.v0.8.1

--- a/docs/deployment/openshift/uninstall.md
+++ b/docs/deployment/openshift/uninstall.md
@@ -1,0 +1,99 @@
+
+# Uninstalling the Operator
+
+When uninstalling the operator, it is important to make sure to uninstall the deployed custom resources first *before* you uninstall the operator.
+This will insure proper cleanup of the resources.
+
+## Option 1: Via the web console
+
+- To uninstall in the OpenShift Web Console (GUI), expand the `Operators` menu and click on `Installed Operators`.
+
+   ![OpenShift CrowdStrike Operator Uninstall](images/ocp-uninstall.png)
+
+### Uninstall the Node Sensor
+
+Follow these steps if you are using the node sensor (the node sensor is the recommended install option):
+
+- Click on the `CrowdStrike Falcon Platform - Operator` listing, followed by clicking on the `Falcon Node Sensor` tab.
+
+   ![OpenShift CrowdStrike Node Sensor Uninstall](images/ocp-nodetab.png)
+
+- On the deployed `FalconNodeSensor` Kind, click the 3 vertical dot action menu on the far right, and click `Delete FalconNodeSensor`.
+
+   ![OpenShift CrowdStrike Node Sensor Uninstall](images/ocp-nodedel.png)
+
+### Uninstall the Sidecar Sensor
+
+Follow these steps if you are using the sidecar sensor (the sidecar sensor is a rarely used alternate install option):
+
+- Click on the `CrowdStrike Falcon Platform - Operator` listing, followed by clicking on the `Falcon Container` tab.
+
+   ![OpenShift CrowdStrike Sidecar Uninstall](images/ocp-containertab.png)
+
+- On the deployed `FalconContainer` Kind, click the 3 vertical dot action menu on the far right, and click `Delete FalconContainer`.
+
+   ![OpenShift CrowdStrike Sidecar Uninstall](images/ocp-containerdel.png)
+
+### Uninstall the Operator
+
+- In the list of `Installed Operators`, click the 3 vertical dot action menu on the far right of the `CrowdStrike Falcon Platform - Operator` listing, and click `Uninstall Operator`.
+
+   ![OpenShift CrowdStrike Operator Uninstall](images/ocp-uninstall2.png)
+
+  This will open an uninstall confirmation box, click `Uninstall` to complete the uninstall.
+
+## Option 2: Via the CLI
+
+#### Uninstall using the Krew plugin (Preferred)
+
+The operator is easily uninstalled using Krew and its operator management plugin:
+
+1. Install Krew. See https://krew.sigs.k8s.io/docs/user-guide/setup/install/
+2. Verify install with `oc krew`
+3. Update krew `oc krew update`
+4. Install the operator krew plugin `oc krew install operator`
+
+Once the Krew plugin is installed:
+
+1. Using the krew plugin, uninstall the certified operator:
+   ```
+   oc operator uninstall falcon-operator-rhmp -n falcon-operator -X
+   ```
+
+## Option 3: Via manifest files
+
+### Uninstall the Node Sensor
+
+- To uninstall the node sensor, simply remove the FalconNodeSensor resource.
+  ```
+  oc delete falconnodesensor -A --all
+  ```
+
+### Uninstall the Sidecar Sensor
+
+- To uninstall Falcon Container simply remove FalconContainer resource. The operator will uninstall Falcon Container product from the cluster.
+  ```
+  oc delete falconcontainers.falcon.crowdstrike.com default
+  ```
+
+### Uninstall the Operator
+
+- To uninstall Falcon Operator, get the name of the subscription that the operator was installed with:
+  ```
+  oc get sub -n falcon-operator
+  ```
+
+- Remove the subscription for the operator:
+  ```
+  oc delete sub falcon-operator -n falcon-operator
+  ```
+
+- Get the name of the ClusterServiceVersion for the operator.
+  ```
+  oc get csv -n falcon-operator
+  ```
+
+- Remove the ClusterServiceVersion for the operator. In this example, version 0.8.0 will be removed:
+  ```
+  oc delete csv falcon-operator.v0.8.0 -n falcon-operator
+  ```

--- a/docs/deployment/openshift/uninstall.md
+++ b/docs/deployment/openshift/uninstall.md
@@ -1,5 +1,5 @@
 
-# Uninstalling the Operator
+# Uninstalling the operator
 
 When uninstalling the operator, it is important to make sure to uninstall the deployed custom resources first *before* you uninstall the operator.
 This will insure proper cleanup of the resources.


### PR DESCRIPTION
This change makes the OpenShift deployment guide more succinct and opinionated.

- Align readme with AWS prescriptive guidance format.
- Clearly favor the node sensor deployment. Move container sensor deployment to its own doc.
- Move uninstall guide to its own doc.