### PR TITLE
refactor: code re-user for certs, pods ready check, ImageRefresher, etc.

### DIFF
--- a/internal/controller/common/utils.go
+++ b/internal/controller/common/utils.go
@@ -1,0 +1,31 @@
+package common
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func GetReadyPod(r client.Client, ctx context.Context, namespace string, matchingLabels client.MatchingLabels) (*corev1.Pod, error) {
+	podList := &corev1.PodList{}
+	listOpts := []client.ListOption{
+		client.InNamespace(namespace),
+		matchingLabels,
+	}
+
+	if err := r.List(ctx, podList, listOpts...); err != nil {
+		return nil, fmt.Errorf("unable to list pods: %v", err)
+	}
+
+	for _, pod := range podList.Items {
+		for _, cond := range pod.Status.Conditions {
+			if cond.Type == corev1.PodReady && cond.Status == corev1.ConditionTrue {
+				return &pod, nil
+			}
+		}
+	}
+
+	return &corev1.Pod{}, fmt.Errorf("No Injector pod found in a Ready state")
+}

--- a/internal/controller/common/utils_test.go
+++ b/internal/controller/common/utils_test.go
@@ -1,0 +1,1 @@
+package common

--- a/internal/controller/image/image_refresher.go
+++ b/internal/controller/image/image_refresher.go
@@ -1,0 +1,132 @@
+package image
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/go-logr/logr"
+
+	"github.com/containers/image/v5/copy"
+	"github.com/containers/image/v5/signature"
+	"github.com/containers/image/v5/transports/alltransports"
+	"github.com/containers/image/v5/types"
+
+	"github.com/crowdstrike/falcon-operator/pkg/registry/auth"
+	"github.com/crowdstrike/falcon-operator/pkg/registry/falcon_registry"
+	"github.com/crowdstrike/gofalcon/falcon"
+)
+
+type ImageRefresher struct {
+	ctx                   context.Context
+	log                   logr.Logger
+	falconConfig          *falcon.ApiConfig
+	insecureSkipTLSVerify bool
+	pushCredentials       auth.Credentials
+}
+
+func NewImageRefresher(ctx context.Context, log logr.Logger, falconConfig *falcon.ApiConfig, pushAuth auth.Credentials, insecureSkipTLSVerify bool) *ImageRefresher {
+	return &ImageRefresher{
+		ctx:                   ctx,
+		log:                   log,
+		falconConfig:          falconConfig,
+		insecureSkipTLSVerify: insecureSkipTLSVerify,
+		pushCredentials:       pushAuth,
+	}
+}
+
+func (r *ImageRefresher) Refresh(imageDestination string, versionRequested *string) (string, error) {
+	falconTag, srcRef, sourceCtx, err := r.source(versionRequested)
+	if err != nil {
+		return "", err
+	}
+
+	r.log.Info("Identified the latest Falcon Container image", "reference", srcRef.DockerReference().String())
+
+	policy := &signature.Policy{Default: []signature.PolicyRequirement{signature.NewPRInsecureAcceptAnything()}}
+	policyContext, err := signature.NewPolicyContext(policy)
+	if err != nil {
+		return "", fmt.Errorf("Error loading trust policy: %v", err)
+	}
+	defer func() { _ = policyContext.Destroy() }()
+
+	destinationCtx, err := r.destinationContext(r.insecureSkipTLSVerify)
+	if err != nil {
+		return "", err
+	}
+
+	// Push to the registry with the falconTag
+	dest := fmt.Sprintf("docker://%s:%s", imageDestination, falconTag)
+	destRef, err := alltransports.ParseImageName(dest)
+
+	if err != nil {
+		return "", fmt.Errorf("Invalid destination name %s: %v", dest, err)
+	}
+
+	r.log.Info("Identified the target location for image push", "reference", destRef.DockerReference().String())
+	_, err = copy.Image(r.ctx, policyContext, destRef, srcRef,
+		&copy.Options{
+			ReportWriter:   os.Stdout,
+			SourceCtx:      sourceCtx,
+			DestinationCtx: destinationCtx,
+		},
+	)
+	if err != nil {
+		return "", wrapWithHint(err)
+	}
+
+	// Push to the registry with the latest tag
+	dest = fmt.Sprintf("docker://%s", imageDestination)
+	destRef, err = alltransports.ParseImageName(dest)
+	if err != nil {
+		return "", fmt.Errorf("Invalid destination name %s: %v", dest, err)
+	}
+
+	r.log.Info("Identified the target location for image push", "reference", destRef.DockerReference().String())
+	_, err = copy.Image(r.ctx, policyContext, destRef, srcRef,
+		&copy.Options{
+			ReportWriter:   os.Stdout,
+			SourceCtx:      sourceCtx,
+			DestinationCtx: destinationCtx,
+		},
+	)
+
+	return falconTag, wrapWithHint(err)
+}
+
+func (r *ImageRefresher) source(versionRequested *string) (falconTag string, falconImage types.ImageReference, systemContext *types.SystemContext, err error) {
+	registry, err := falcon_registry.NewFalconRegistry(r.ctx, r.falconConfig)
+	if err != nil {
+		return
+	}
+
+	return registry.PullInfo(r.ctx, versionRequested)
+}
+
+func (r *ImageRefresher) destinationContext(insecureSkipTLSVerify bool) (*types.SystemContext, error) {
+	ctx, err := r.pushCredentials.DestinationContext()
+	if err != nil {
+		return nil, err
+	}
+
+	if insecureSkipTLSVerify {
+		ctx.DockerInsecureSkipTLSVerify = 1
+	}
+
+	return ctx, nil
+}
+
+func wrapWithHint(in error) error {
+	// Use of credentials store outside of docker command is somewhat limited
+	// See https://github.com/moby/moby/issues/39377
+	// https://github.com/containers/image/pull/656
+	if in == nil {
+		return in
+	}
+
+	if strings.Contains(in.Error(), "authentication required") {
+		return fmt.Errorf("Could not authenticate to the registry: %w", in)
+	}
+	return in
+}

--- a/pkg/aws/ecr.go
+++ b/pkg/aws/ecr.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/service/ecr"
+	"github.com/aws/aws-sdk-go-v2/service/ecr/types"
 	ecr_types "github.com/aws/aws-sdk-go-v2/service/ecr/types"
 )
 
@@ -40,4 +41,18 @@ func (c *Config) ECRLogin(ctx context.Context) ([]byte, error) {
 		return nil, fmt.Errorf("Cannot get authorization token fro ECR.")
 	}
 	return base64.StdEncoding.DecodeString(*output.AuthorizationData[0].AuthorizationToken)
+}
+
+func UpsertECRRepo(ctx context.Context, name string) (*types.Repository, error) {
+	cfg, err := NewConfig()
+	if err != nil {
+		return nil, fmt.Errorf("Failed to initialise connection to AWS. Please make sure that kubernetes service account falcon-operator has access to AWS IAM role and OIDC Identity provider is running on the cluster. Error was: %v", err)
+	}
+
+	data, err := cfg.UpsertRepository(ctx, name)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to upsert ECR repository: %v", err)
+	}
+
+	return data, nil
 }

--- a/pkg/tls/certs.go
+++ b/pkg/tls/certs.go
@@ -11,8 +11,13 @@ import (
 	"time"
 )
 
+type CertInfo struct {
+	CommonName string
+	DNSNames   []string
+}
+
 // CertSetup will generate and return tls certs
-func CertSetup(days int) ([]byte, []byte, []byte, error) {
+func CertSetup(days int, certInfo CertInfo) ([]byte, []byte, []byte, error) {
 	// set up our CA certificate
 	ca := &x509.Certificate{
 		SerialNumber: new(big.Int).Lsh(big.NewInt(1), 128),
@@ -60,14 +65,14 @@ func CertSetup(days int) ([]byte, []byte, []byte, error) {
 	cert := &x509.Certificate{
 		SerialNumber: new(big.Int).Lsh(big.NewInt(1), 128),
 		Subject: pkix.Name{
-			CommonName: "falcon-sidecar-injector.falcon-system.svc",
+			CommonName: certInfo.CommonName,
 		},
 		NotBefore:    time.Now(),
 		NotAfter:     time.Now().AddDate(0, 0, days),
 		SubjectKeyId: []byte("234567"),
 		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
 		KeyUsage:     x509.KeyUsageDigitalSignature,
-		DNSNames:     []string{"falcon-sidecar-injector.falcon-system.svc", "falcon-sidecar-injector.falcon-system.svc.cluster.local"},
+		DNSNames:     certInfo.DNSNames,
 	}
 
 	certPrivKey, err := rsa.GenerateKey(rand.Reader, 2048)


### PR DESCRIPTION
- Allows code re-use of TLS cert creation, checking if pods are ready before deploying, ImageFresher for registry pushing, etc. as more reconcilation types will need to be able to do the same thing.