### PR TITLE
Fix label for Falcon Proxy Host

### DIFF
--- a/api/falcon/v1alpha1/falcon.go
+++ b/api/falcon/v1alpha1/falcon.go
@@ -14,7 +14,7 @@ type FalconSensor struct {
 	APD *bool `json:"apd,omitempty"`
 
 	// The application proxy host to use for Falcon sensor proxy configuration.
-	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Disable Falcon Proxy Host",order=4
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Falcon Proxy Host",order=4
 	APH string `json:"aph,omitempty"`
 
 	// The application proxy port to use for Falcon sensor proxy configuration.


### PR DESCRIPTION
Fixing the label of the proxy host (before : `Disable Falcon Proxy Host` => after: `Falcon Proxy Host` )

I've updated the 2 yaml files because I don't know if they were automatically generated (I can delete the additional commit if needed)