### PR TITLE
Bump OpenShift Subscription example's channel to 0.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The CrowdStrike Falcon Operator deploys CrowdStrike Falcon to the cluster. The o
 
 ## Installation and Deployment
 
-For installation and deployment of the CrowdStrike Falcon Operator and its Custom Resources, please read the [Installation and Deployment Guide](./docs/install_guide.md) and choose the deployment method that is right for your target environment.
+For installation and deployment of the CrowdStrike Falcon Operator and its Custom Resources, please read the [Installation and Deployment Guide](docs/install_guide.md) and choose the deployment method that is right for your target environment.
 
 ## Getting Help
 If you encounter any issues while using the Falcon Operator, you can create an issue on our [Github repo](https://github.com/CrowdStrike/falcon-operator) for bugs, enhancements, or other requests.

--- a/docs/deployment/openshift/redhat-subscription.yaml
+++ b/docs/deployment/openshift/redhat-subscription.yaml
@@ -3,7 +3,7 @@ kind: Subscription
 metadata:
   name: falcon-operator
 spec:
-  channel: certified-0.8
+  channel: certified-0.9
   name: falcon-operator-rhmp
   source: redhat-marketplace
   sourceNamespace: openshift-marketplace

--- a/docs/src/deployment/openshift/redhat-subscription.yaml
+++ b/docs/src/deployment/openshift/redhat-subscription.yaml
@@ -3,7 +3,7 @@ kind: Subscription
 metadata:
   name: falcon-operator
 spec:
-  channel: certified-0.8
+  channel: certified-0.9
   name: falcon-operator-rhmp
   source: redhat-marketplace
   sourceNamespace: openshift-marketplace


### PR DESCRIPTION
Tweaks discovered while writing AWS prescriptive guidance:
- Update the Subscription YAML example so it's pointing to the latest channel by default (no --edit/knowledge needed)
- Markdown link starting with `./` doesn't render to a github.com link in OperatorHub. Removing it does (see Developer Documentation link which works correctly).