### PR TITLE
cleanup: remove logging from version.go

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -92,8 +92,6 @@ func main() {
 		os.Exit(0)
 	}
 
-	version.Print()
-
 	options := ctrl.Options{
 		Scheme:                 scheme,
 		MetricsBindAddress:     metricsAddr,
@@ -197,7 +195,7 @@ func main() {
 		}()
 	}
 
-	setupLog.Info("starting manager")
+	setupLog.Info("starting manager", "version", version.Get(), "go version", version.GoVersion)
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)

--- a/version/version.go
+++ b/version/version.go
@@ -3,22 +3,12 @@ package version
 import (
 	"fmt"
 	"runtime"
-
-	ctrl "sigs.k8s.io/controller-runtime"
 )
-
-var log = ctrl.Log.WithName("version")
 
 var (
 	Version   = "" // version will be replaced while building the binary using ldflags
 	GoVersion = fmt.Sprintf("%s %s/%s", runtime.Version(), runtime.GOOS, runtime.GOARCH)
 )
-
-// Print() logs the operator version and related information
-func Print() {
-	log.Info("operator", "version", Version)
-	log.Info("go", "version", GoVersion)
-}
 
 // Get() returns the operator version
 func Get() string {

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -1,14 +1,8 @@
 package version
 
 import (
-	"bufio"
-	"bytes"
 	"regexp"
-	"strings"
 	"testing"
-
-	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
 func TestEmptyVersion(t *testing.T) {
@@ -37,30 +31,5 @@ func TestGet(t *testing.T) {
 	ver := Get()
 	if ver != "" {
 		t.Error("Get returned value, expected only empty string. Got:", ver)
-	}
-}
-
-func TestPrint(t *testing.T) {
-	var buffer bytes.Buffer
-
-	opts := zap.Options{
-		Development: true,
-	}
-
-	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts), zap.WriteTo(&buffer)))
-	writer := bufio.NewWriter(&buffer)
-	log = ctrl.Log.WithName("version")
-
-	Print()
-	writer.Flush()
-
-	printOutput := buffer.String()
-
-	if printOutput == "" {
-		t.Error("Print returned empty string, expected value. Got:", printOutput)
-	}
-
-	if !strings.Contains(printOutput, "{\"version\": \"\"}") && !strings.Contains(printOutput, "{\"go-version\": \"go") {
-		t.Error("Print returned unexpected value. Got:", printOutput)
 	}
 }


### PR DESCRIPTION
- removes the need for logging which is unnecessary in version.go