### PR TITLE
fix(admission): always return existing tls certs on reconciliation

### DIFF
--- a/internal/controller/assets/deployment.go
+++ b/internal/controller/assets/deployment.go
@@ -439,7 +439,7 @@ func AdmissionDeployment(name string, namespace string, component string, imageU
 							Ports: []corev1.ContainerPort{
 								{
 									ContainerPort: *falconAdmission.Spec.AdmissionConfig.ContainerPort,
-									Name:          common.FalconAdmissionServiceHTTPSName,
+									Name:          common.FalconServiceHTTPSName,
 									Protocol:      corev1.ProtocolTCP,
 								},
 							},

--- a/internal/controller/assets/deployment_test.go
+++ b/internal/controller/assets/deployment_test.go
@@ -455,7 +455,7 @@ func testAdmissionDeployment(name string, namespace string, component string, im
 							Ports: []corev1.ContainerPort{
 								{
 									ContainerPort: *falconAdmission.Spec.AdmissionConfig.Port,
-									Name:          common.FalconAdmissionServiceHTTPSName,
+									Name:          common.FalconServiceHTTPSName,
 									Protocol:      corev1.ProtocolTCP,
 								},
 							},

--- a/internal/controller/assets/validatingwebhook.go
+++ b/internal/controller/assets/validatingwebhook.go
@@ -11,7 +11,7 @@ func ValidatingWebhook(name string, namespace string, webhookName string, caBund
 	failurePolicy := arv1.Ignore
 	matchPolicy := arv1.Equivalent
 	sideEffects := arv1.SideEffectClassNone
-	timeoutSeconds := int32(5)
+	timeoutSeconds := int32(10)
 	operatorSelector := metav1.LabelSelectorOpNotIn
 	path := "/validate"
 	scope := arv1.AllScopes
@@ -24,9 +24,12 @@ func ValidatingWebhook(name string, namespace string, webhookName string, caBund
 			Kind:       "ValidatingWebhookConfiguration",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
+			Name:      webhookName,
 			Namespace: namespace,
 			Labels:    labels,
+			Annotations: map[string]string{
+				"admissions.enforcer/disabled": "true",
+			},
 		},
 		Webhooks: []arv1.ValidatingWebhook{
 			{

--- a/internal/controller/assets/validatingwebhook_test.go
+++ b/internal/controller/assets/validatingwebhook_test.go
@@ -24,7 +24,7 @@ func testValidatingWebhook(name string, namespace string, webhookName string, ca
 	failurePolicy := arv1.Ignore
 	matchPolicy := arv1.Equivalent
 	sideEffects := arv1.SideEffectClassNone
-	timeoutSeconds := int32(5)
+	timeoutSeconds := int32(10)
 	operatorSelector := metav1.LabelSelectorOpNotIn
 	path := "/validate"
 	scope := arv1.AllScopes
@@ -37,9 +37,10 @@ func testValidatingWebhook(name string, namespace string, webhookName string, ca
 			Kind:       "ValidatingWebhookConfiguration",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-			Labels:    labels,
+			Name:        name,
+			Namespace:   namespace,
+			Labels:      labels,
+			Annotations: map[string]string{"admissions.enforcer/disabled": "true"},
 		},
 		Webhooks: []arv1.ValidatingWebhook{
 			{

--- a/internal/controller/falcon_container/injector.go
+++ b/internal/controller/falcon_container/injector.go
@@ -42,7 +42,7 @@ func (r *FalconContainerReconciler) reconcileInjectorTLSSecret(ctx context.Conte
 				DNSNames:   []string{fmt.Sprintf("%s.%s.svc", injectorName, r.Namespace()), fmt.Sprintf("%s.%s.svc.cluster.local", injectorName, r.Namespace())},
 			}
 
-			c, k, b, err := tls.CertSetup(validity, certInfo)
+			c, k, b, err := tls.CertSetup(r.Namespace(), validity, certInfo)
 			if err != nil {
 				return &corev1.Secret{}, fmt.Errorf("failed to generate Falcon Container PKI: %v", err)
 			}

--- a/pkg/tls/certs.go
+++ b/pkg/tls/certs.go
@@ -17,18 +17,18 @@ type CertInfo struct {
 }
 
 // CertSetup will generate and return tls certs
-func CertSetup(days int, certInfo CertInfo) ([]byte, []byte, []byte, error) {
+func CertSetup(namespace string, days int, certInfo CertInfo) ([]byte, []byte, []byte, error) {
 	// set up our CA certificate
 	ca := &x509.Certificate{
 		SerialNumber: new(big.Int).Lsh(big.NewInt(1), 128),
 		Subject: pkix.Name{
-			CommonName: "falcon-system ca",
+			CommonName: namespace + " ca",
 		},
 		NotBefore:             time.Now(),
 		NotAfter:              time.Now().AddDate(0, 0, days),
 		IsCA:                  true,
-		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
-		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment | x509.KeyUsageCertSign,
 		BasicConstraintsValid: true,
 	}
 
@@ -67,12 +67,13 @@ func CertSetup(days int, certInfo CertInfo) ([]byte, []byte, []byte, error) {
 		Subject: pkix.Name{
 			CommonName: certInfo.CommonName,
 		},
-		NotBefore:    time.Now(),
-		NotAfter:     time.Now().AddDate(0, 0, days),
-		SubjectKeyId: []byte("234567"),
-		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
-		KeyUsage:     x509.KeyUsageDigitalSignature,
-		DNSNames:     certInfo.DNSNames,
+		NotBefore:      time.Now(),
+		NotAfter:       time.Now().AddDate(0, 0, days),
+		AuthorityKeyId: ca.SubjectKeyId,
+		ExtKeyUsage:    []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:       x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		IsCA:           false,
+		DNSNames:       certInfo.DNSNames,
 	}
 
 	certPrivKey, err := rsa.GenerateKey(rand.Reader, 2048)


### PR DESCRIPTION
- Configure new default timeout for webhook