### PR TITLE
feat: allow sidecar sensor to customize namespace

### DIFF
--- a/api/falcon/v1alpha1/falconcontainer_types.go
+++ b/api/falcon/v1alpha1/falconcontainer_types.go
@@ -14,6 +14,13 @@ type FalconContainerSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
+	// Namespace where the Falcon Sensor should be installed.
+	// For best security practices, this should be a dedicated namespace that is not used for any other purpose.
+	// It also should not be the same namespace where the Falcon Operator, or other Falcon resources are deployed.
+	// +kubebuilder:default:=falcon-system
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,order=1,xDescriptors={"urn:alm:descriptor:io.kubernetes:Namespace"}
+	InstallNamespace string `json:"installNamespace,omitempty"`
+
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Falcon Sensor Configuration",order=1
 	Falcon FalconSensor `json:"falcon,omitempty"`
 	// FalconAPI configures connection from your local Falcon operator to CrowdStrike Falcon platform.

--- a/config/crd/bases/falcon.crowdstrike.com_falconcontainers.yaml
+++ b/config/crd/bases/falcon.crowdstrike.com_falconcontainers.yaml
@@ -1877,6 +1877,14 @@ spec:
                         x-kubernetes-int-or-string: true
                     type: object
                 type: object
+              installNamespace:
+                default: falcon-system
+                description: Namespace where the Falcon Sensor should be installed.
+                  For best security practices, this should be a dedicated namespace
+                  that is not used for any other purpose. It also should not be the
+                  same namespace where the Falcon Operator, or other Falcon resources
+                  are deployed.
+                type: string
               registry:
                 description: Registry configures container image registry to which
                   the Falcon Container image will be pushed

--- a/deploy/falcon-operator.yaml
+++ b/deploy/falcon-operator.yaml
@@ -2437,6 +2437,14 @@ spec:
                         x-kubernetes-int-or-string: true
                     type: object
                 type: object
+              installNamespace:
+                default: falcon-system
+                description: Namespace where the Falcon Sensor should be installed.
+                  For best security practices, this should be a dedicated namespace
+                  that is not used for any other purpose. It also should not be the
+                  same namespace where the Falcon Operator, or other Falcon resources
+                  are deployed.
+                type: string
               registry:
                 description: Registry configures container image registry to which
                   the Falcon Container image will be pushed

--- a/docs/deployment/openshift/resources/container/README.md
+++ b/docs/deployment/openshift/resources/container/README.md
@@ -55,6 +55,7 @@ spec:
 #### Sidecar Injection Configuration Settings
 | Spec                                      | Description                                                                                                                                                                                                             |
 | :----------------------------------       | :------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| installNamespace                          | (optional) Override the default namespace of falcon-sidecar                                                                                                                                                                 |
 | image                                     | (optional) Leverage a Falcon Container Sensor image that is not managed by the operator; typically used with custom repositories; overrides all registry settings; might require injector.imagePullSecretName to be set |
 | version                                   | (optional) Enforce particular Falcon Container version to be installed (example: "6.31", "6.31.0", "6.31.0-1409")                                                                                                       |
 | registry.type                             | Registry to mirror Falcon Container (allowed values: acr, ecr, crowdstrike, gcr, openshift)                                              |

--- a/docs/resources/container/README.md
+++ b/docs/resources/container/README.md
@@ -55,6 +55,7 @@ spec:
 #### Sidecar Injection Configuration Settings
 | Spec                                      | Description                                                                                                                                                                                                             |
 | :----------------------------------       | :------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| installNamespace                          | (optional) Override the default namespace of falcon-sidecar                                                                                                                                                                 |
 | image                                     | (optional) Leverage a Falcon Container Sensor image that is not managed by the operator; typically used with custom repositories; overrides all registry settings; might require injector.imagePullSecretName to be set |
 | version                                   | (optional) Enforce particular Falcon Container version to be installed (example: "6.31", "6.31.0", "6.31.0-1409")                                                                                                       |
 | registry.type                             | Registry to mirror Falcon Container (allowed values: acr, ecr, crowdstrike, gcr, openshift)                                              |

--- a/docs/src/resources/container.md.tmpl
+++ b/docs/src/resources/container.md.tmpl
@@ -55,6 +55,7 @@ spec:
 #### Sidecar Injection Configuration Settings
 | Spec                                      | Description                                                                                                                                                                                                             |
 | :----------------------------------       | :------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| installNamespace                          | (optional) Override the default namespace of falcon-sidecar                                                                                                                                                                 |
 | image                                     | (optional) Leverage a Falcon Container Sensor image that is not managed by the operator; typically used with custom repositories; overrides all registry settings; might require injector.imagePullSecretName to be set |
 | version                                   | (optional) Enforce particular Falcon Container version to be installed (example: "6.31", "6.31.0", "6.31.0-1409")                                                                                                       |
 | registry.type                             | Registry to mirror Falcon Container (allowed values: acr, ecr, crowdstrike, gcr, openshift)                                              |

--- a/internal/controller/falcon_container/image_push.go
+++ b/internal/controller/falcon_container/image_push.go
@@ -228,7 +228,7 @@ func (r *FalconContainerReconciler) imageNamespace(falconContainer *falconv1alph
 		// is shared and images pushed there can be referenced by deployments in other namespaces
 		return "openshift"
 	}
-	return r.Namespace()
+	return falconContainer.Spec.InstallNamespace
 }
 
 func (r *FalconContainerReconciler) falconApiConfig(ctx context.Context, falconContainer *falconv1alpha1.FalconContainer) *falcon.ApiConfig {

--- a/internal/controller/falcon_container/rbac.go
+++ b/internal/controller/falcon_container/rbac.go
@@ -25,7 +25,7 @@ func (r *FalconContainerReconciler) reconcileServiceAccount(ctx context.Context,
 	update := false
 	serviceAccount := r.newServiceAccount(falconContainer)
 	existingServiceAccount := &corev1.ServiceAccount{}
-	err := r.Client.Get(ctx, types.NamespacedName{Name: common.SidecarServiceAccountName, Namespace: r.Namespace()}, existingServiceAccount)
+	err := r.Client.Get(ctx, types.NamespacedName{Name: common.SidecarServiceAccountName, Namespace: falconContainer.Spec.InstallNamespace}, existingServiceAccount)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			if err = ctrl.SetControllerReference(falconContainer, serviceAccount, r.Scheme); err != nil {
@@ -94,7 +94,7 @@ func (r *FalconContainerReconciler) newServiceAccount(falconContainer *falconv1a
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        common.SidecarServiceAccountName,
-			Namespace:   r.Namespace(),
+			Namespace:   falconContainer.Spec.InstallNamespace,
 			Labels:      common.CRLabels("serviceaccount", common.SidecarServiceAccountName, common.FalconSidecarSensor),
 			Annotations: falconContainer.Spec.Injector.ServiceAccount.Annotations,
 		},
@@ -115,7 +115,7 @@ func (r *FalconContainerReconciler) newClusterRoleBinding(falconContainer *falco
 		Subjects: []rbacv1.Subject{{
 			Kind:      "ServiceAccount",
 			Name:      common.SidecarServiceAccountName,
-			Namespace: r.Namespace(),
+			Namespace: falconContainer.Spec.InstallNamespace,
 		}},
 		RoleRef: rbacv1.RoleRef{
 			APIGroup: "rbac.authorization.k8s.io",

--- a/internal/controller/falcon_container/registry.go
+++ b/internal/controller/falcon_container/registry.go
@@ -43,12 +43,12 @@ func (r *FalconContainerReconciler) reconcileRegistrySecrets(ctx context.Context
 		if disableDefaultNSInjection {
 			// if default namespace injection is disabled, require that the injection label be set to enabled
 			// in both cases below, ensure that we're not blocking pull secret creation within the injector namespace
-			if (ns.Labels == nil || ns.Labels[common.FalconContainerInjection] != injectionEnabledValue) && ns.Name != r.Namespace() {
+			if (ns.Labels == nil || ns.Labels[common.FalconContainerInjection] != injectionEnabledValue) && ns.Name != falconContainer.Spec.InstallNamespace {
 				continue
 			}
 		} else {
 			// otherwise, just ensure the injection label is not set to disabled
-			if ns.Labels != nil && ns.Labels[common.FalconContainerInjection] == injectionDisabledValue && ns.Name != r.Namespace() {
+			if ns.Labels != nil && ns.Labels[common.FalconContainerInjection] == injectionDisabledValue && ns.Name != falconContainer.Spec.InstallNamespace {
 				continue
 			}
 		}

--- a/internal/controller/falcon_container/service.go
+++ b/internal/controller/falcon_container/service.go
@@ -17,11 +17,11 @@ import (
 
 func (r *FalconContainerReconciler) reconcileService(ctx context.Context, log logr.Logger, falconContainer *falconv1alpha1.FalconContainer) (*corev1.Service, error) {
 	selector := map[string]string{common.FalconComponentKey: common.FalconSidecarSensor}
-	service := assets.Service(injectorName, r.Namespace(), common.FalconSidecarSensor, selector, common.FalconServiceHTTPSName, *falconContainer.Spec.Injector.ListenPort)
+	service := assets.Service(injectorName, falconContainer.Spec.InstallNamespace, common.FalconSidecarSensor, selector, common.FalconServiceHTTPSName, *falconContainer.Spec.Injector.ListenPort)
 	updated := false
 	existingService := &corev1.Service{}
 
-	err := r.Client.Get(ctx, types.NamespacedName{Name: injectorName, Namespace: r.Namespace()}, existingService)
+	err := r.Client.Get(ctx, types.NamespacedName{Name: injectorName, Namespace: falconContainer.Spec.InstallNamespace}, existingService)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			if err = ctrl.SetControllerReference(falconContainer, service, r.Scheme); err != nil {

--- a/internal/controller/falcon_container/webhook.go
+++ b/internal/controller/falcon_container/webhook.go
@@ -25,7 +25,7 @@ func (r *FalconContainerReconciler) reconcileWebhook(ctx context.Context, log lo
 		disableDefaultNSInjection = falconContainer.Spec.Injector.DisableDefaultNSInjection
 	}
 
-	webhook := assets.MutatingWebhook(injectorName, r.Namespace(), webhookName, caBundle, disableDefaultNSInjection, falconContainer)
+	webhook := assets.MutatingWebhook(injectorName, falconContainer.Spec.InstallNamespace, webhookName, caBundle, disableDefaultNSInjection, falconContainer)
 	existingWebhook := &arv1.MutatingWebhookConfiguration{}
 
 	err := r.Client.Get(ctx, types.NamespacedName{Name: webhookName}, existingWebhook)


### PR DESCRIPTION
- Useful for mixed EKS clusters
- Needed for certain customer workloads to be able to customize namespace.
- Prevents running a non-privileged workload next to a privileged workload