### PR TITLE
fix: upgrade controller-tools to v0.15.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -220,7 +220,7 @@ ENVTEST ?= $(LOCALBIN)/setup-envtest
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v5.2.1
-CONTROLLER_TOOLS_VERSION ?= v0.13.0
+CONTROLLER_TOOLS_VERSION ?= v0.15.0
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary. If wrong version is installed, it will be removed before downloading.


### PR DESCRIPTION
[controller-gen crashes on Go 1.22](https://github.com/kubernetes-sigs/controller-tools/issues/880) due to a change in Golang itself. Upgrading to the latest fixes the issue.