### PR TITLE
fix: only run release workflow on full releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - "v*"
+      - "v[0-9]+.[0-9]+.[0-9]+"
 
 permissions:
   contents: write # publishing releases


### PR DESCRIPTION
The GitHub Actions [release workflow](https://github.com/CrowdStrike/falcon-operator/blob/main/.github/workflows/release.yml) currently runs on any tag that begins with a lowercase V, including prerelease tags. This change limits the action to full releases only.