### PR TITLE
feat: allow API host override during NodeSensor config-cache tests

### DIFF
--- a/api/falcon/v1alpha1/falcon_api.go
+++ b/api/falcon/v1alpha1/falcon_api.go
@@ -28,6 +28,10 @@ type FalconAPI struct {
 	// +kubebuilder:validation:Pattern="^[0-9a-fA-F]{32}-[0-9a-fA-F]{2}$"
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Falcon Customer ID (CID)",order=4
 	CID *string `json:"cid,omitempty"`
+
+	// Specifies the hostname of the API endpoint to use. If blank, the public Falcon API endpoint is used.
+	// Intentionally not exported as a resource property.
+	HostOverride string `json:"-"`
 }
 
 // RegistryTLSSpec configures TLS for registry pushing
@@ -82,6 +86,7 @@ func (fa *FalconAPI) ApiConfig() *falcon.ApiConfig {
 		Cloud:             falcon.Cloud(fa.CloudRegion),
 		ClientId:          fa.ClientId,
 		ClientSecret:      fa.ClientSecret,
+		HostOverride:      fa.HostOverride,
 		UserAgentOverride: fmt.Sprintf("falcon-operator/%s", version.Version),
 	}
 }

--- a/pkg/node/config_cache_test.go
+++ b/pkg/node/config_cache_test.go
@@ -83,11 +83,8 @@ func TestGetPullToken(t *testing.T) {
 		t.Errorf("GetPullToken() = %s, want %s", got, "not empty")
 	}
 
-	config.nodesensor.Spec.FalconAPI = &falconv1alpha1.FalconAPI{
-		ClientId:     "testID",
-		ClientSecret: "testSecret",
-		CloudRegion:  "testRegion",
-	}
+	var noCID *string
+	config.nodesensor.Spec.FalconAPI = newTestFalconAPI(noCID)
 	got, err = config.GetPullToken(context.Background())
 	if err != nil {
 		if strings.Contains(err.Error(), "401 Unauthorized") {
@@ -132,12 +129,7 @@ func TestNewConfigCache(t *testing.T) {
 		t.Errorf("NewConfigCache() = %v, want %v", newCache, want)
 	}
 
-	config.nodesensor.Spec.FalconAPI = &falconv1alpha1.FalconAPI{
-		ClientId:     "testID",
-		ClientSecret: "testSecret",
-		CloudRegion:  "testRegion",
-		CID:          &falconCID,
-	}
+	config.nodesensor.Spec.FalconAPI = newTestFalconAPI(&falconCID)
 	newCache, err = NewConfigCache(context.Background(), logger, &falconNode)
 	if err != nil {
 		t.Errorf("NewConfigCache() error: %v", err)
@@ -158,12 +150,7 @@ func TestConfigCacheTest(t *testing.T) {
 }
 
 func TestGetFalconImage(t *testing.T) {
-	falconNode.Spec.FalconAPI = &falconv1alpha1.FalconAPI{
-		ClientId:     "testID",
-		ClientSecret: "testSecret",
-		CloudRegion:  "testRegion",
-		CID:          &falconCID,
-	}
+	falconNode.Spec.FalconAPI = newTestFalconAPI(&falconCID)
 
 	testVersion := "testVersion"
 	falconNode.Spec.Node.Version = &testVersion
@@ -209,5 +196,15 @@ func TestGetFalconImage(t *testing.T) {
 	}
 	if want != got {
 		t.Errorf("getFalconImage() = %s, want %s", got, want)
+	}
+}
+
+func newTestFalconAPI(cid *string) *falconv1alpha1.FalconAPI {
+	return &falconv1alpha1.FalconAPI{
+		ClientId:     "testID",
+		ClientSecret: "testSecret",
+		CloudRegion:  "testRegion",
+		CID:          cid,
+		HostOverride: strings.TrimSpace(os.Getenv("FALCON_API_HOST")),
 	}
 }


### PR DESCRIPTION
Tests involving the Falcon API are presently limited to production endpoints. This change adds the ability to override the endpoint by setting the FALCON_API_HOST environment variable. For example:
```
$ FALCON_API_HOST=myhost.example.com make test
```