### PR TITLE
fix: identify maintenance branch associated with release tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,11 +33,16 @@ jobs:
       - name: Get Event branch
         id: event_branch
         run: |
-          BASEREF=${{ github.event.base_ref }}
-          REFBRANCH=${BASEREF#refs/heads/}
+          REFBRANCH=$(git branch -r --contains ${{ github.ref }} --format "%(refname:lstrip=3)" 'origin/maint-*')
 
           echo "REFBRANCH=${REFBRANCH}" >> $GITHUB_ENV
           echo $REFBRANCH
+
+      - name: Verify event branch name
+        if: ${{ env.REFBRANCH == '' }}
+        uses: actions/github-script@v3
+        with:
+          script: core.setFailed('unable to identify maintenance branch associated with release tag')
 
       - name: Checkout tagged branch
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,6 +98,8 @@ jobs:
           git push
           git tag -f "${GITHUB_REF#refs/tags/}"
           git push origin "${GITHUB_REF#refs/tags/}" --force
+    outputs:
+      refBranch: ${{ env.REFBRANCH }}
 
   create_release:
     runs-on: ubuntu-latest
@@ -111,8 +113,7 @@ jobs:
       - name: Get Event branch
         id: event_branch
         run: |
-          BASEREF=${{ github.event.base_ref }}
-          REFBRANCH=${BASEREF#refs/heads/}
+          REFBRANCH=${{ needs.bump_release.outputs.refBranch }}
 
           echo "REFBRANCH=${REFBRANCH}" >> $GITHUB_ENV
           git checkout $REFBRANCH


### PR DESCRIPTION
The `releases.yaml` GitHub workflow was relying on a context variable (`github.event.base_ref`) that is not set during tag pushes, and thus it could not reliably determine on which branch a release tag existed. In addition, it wasn't enforcing the policy of only releasing from a maintenance branch. This PR fixes both of these issues.