### PR TITLE
fix: add missing HTTP transport defaults when bypassing Artifactory

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/onsi/gomega v1.27.7
 	github.com/openshift/api v0.0.0-20220630121623-32f1d77b9f50
 	github.com/operator-framework/operator-lib v0.11.0
+	github.com/stretchr/testify v1.9.0
 	golang.org/x/exp v0.0.0-20240222234643-814bf88cf225
 	k8s.io/api v0.27.2
 	k8s.io/apimachinery v0.27.2
@@ -123,6 +124,7 @@ require (
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/ostreedev/ostree-go v0.0.0-20210805093236-719684c64e4f // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/proglottis/gpgme v0.1.3 // indirect
 	github.com/prometheus/client_golang v1.17.0 // indirect
 	github.com/prometheus/client_model v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -426,6 +426,7 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/sylabs/sif/v2 v2.15.1 h1:75BcunPOY11fVhe02/WHuNLTfDd3OHH0ex0MuuNMYX0=
 github.com/sylabs/sif/v2 v2.15.1/go.mod h1:YiwCUdZOhiohnPbyxuxvCZa+03HwAaiC+vfAKZPR8nQ=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635 h1:kdXcSzyDtseVEc4yCz2qF8ZrQvIDBJLl4S1c3GCXmoI=

--- a/pkg/registry/falcon_registry/registry.go
+++ b/pkg/registry/falcon_registry/registry.go
@@ -137,13 +137,7 @@ func listDockerTags(ctx context.Context, sys *types.SystemContext, imgRef types.
 				return nil, fmt.Errorf("Error parsing repository (%s) from image reference. Missing crowdstrike domain: %v", reg, err)
 			}
 
-			tr := &http.Transport{
-				TLSClientConfig: &tls.Config{
-					MinVersion: tls.VersionTLS12,
-				},
-			}
-
-			client := &http.Client{Transport: tr}
+			client := &http.Client{Transport: newHttpTransport()}
 			req, err := http.NewRequest("GET", fmt.Sprintf("https:%s/tags/list", reg), nil)
 			if err != nil {
 				return nil, err
@@ -184,6 +178,14 @@ func listDockerTags(ctx context.Context, sys *types.SystemContext, imgRef types.
 		return nil, fmt.Errorf("Error listing repository (%s) tags: %v", imgRef.StringWithinTransport(), err)
 	}
 	return tags, nil
+}
+
+func newHttpTransport() *http.Transport {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.TLSClientConfig = &tls.Config{
+		MinVersion: tls.VersionTLS12,
+	}
+	return transport
 }
 
 func (fr *FalconRegistry) systemContext() (*types.SystemContext, error) {

--- a/pkg/registry/falcon_registry/registry_test.go
+++ b/pkg/registry/falcon_registry/registry_test.go
@@ -1,0 +1,16 @@
+package falcon_registry
+
+import (
+	"crypto/tls"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewHttpTransport(t *testing.T) {
+	transport := newHttpTransport()
+	assert.NotNil(t, transport.Proxy, "missing proxy configuration")
+	require.NotNil(t, transport.TLSClientConfig, "missing TLS client config")
+	assert.Equal(t, uint16(tls.VersionTLS12), transport.TLSClientConfig.MinVersion, "wrong minimum TLS version")
+}


### PR DESCRIPTION
A workaround was previously added to bypass an open issue in Artifactory, but that workaround did not use the default HTTP transport provided by the Go library. As a result, some capabilities were missing (e.g. proxy support). This change introduces a transport based on the library default.