### PR TITLE
fix: disable provenance in Docker builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -178,7 +178,7 @@ docker-buildx: ## Build and push docker image for the manager for cross-platform
 	sed -e '1 s/\(^FROM\)/FROM --platform=\$$\{BUILDPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$$\{BUILDPLATFORM\}/' Dockerfile > Dockerfile.cross
 	- $(CONTAINER_TOOL) buildx create --name project-v3-builder
 	$(CONTAINER_TOOL) buildx use project-v3-builder
-	- $(CONTAINER_TOOL) buildx build --push --platform=$(PLATFORMS) $(CONTAINER_BUILD_ARGS) --tag ${IMG} -f Dockerfile.cross .
+	- $(CONTAINER_TOOL) buildx build --push --platform=$(PLATFORMS) $(CONTAINER_BUILD_ARGS) --provenance=false --tag ${IMG} -f Dockerfile.cross .
 	- $(CONTAINER_TOOL) buildx rm project-v3-builder
 	rm Dockerfile.cross
 


### PR DESCRIPTION
[RedHat's oc-mirror tool has difficulty](https://issues.redhat.com/browse/OCPBUGS-37866) with their own image registry if the images contain [provenance attestations](https://docs.docker.com/build/metadata/attestations/slsa-provenance/). Removing attestations still passes OpenShift certification, so for the time being we're doing just that. Once RedHat fixes their tooling we'll add them back in.