### PR TITLE
fix: Override default tolerations for daemonset with empty list

### DIFF
--- a/api/falcon/v1alpha1/falconnodesensor_types.go
+++ b/api/falcon/v1alpha1/falconnodesensor_types.go
@@ -6,26 +6,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var (
-	NodeDefaultTolerations = []corev1.Toleration{
-		{
-			Key:      "node-role.kubernetes.io/master",
-			Operator: "Exists",
-			Effect:   "NoSchedule",
-		},
-		{
-			Key:      "node-role.kubernetes.io/control-plane",
-			Operator: "Exists",
-			Effect:   "NoSchedule",
-		},
-		{
-			Key:      "node-role.kubernetes.io/infra",
-			Operator: "Exists",
-			Effect:   "NoSchedule",
-		},
-	}
-)
-
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
@@ -64,7 +44,7 @@ type FalconNodeSensorConfig struct {
 	// Specifies tolerations for custom taints. Defaults to allowing scheduling on all nodes.
 	// +kubebuilder:default:={{key: "node-role.kubernetes.io/master", operator: "Exists", effect: "NoSchedule"}, {key: "node-role.kubernetes.io/control-plane", operator: "Exists", effect: "NoSchedule"}, {key: "node-role.kubernetes.io/infra", operator: "Exists", effect: "NoSchedule"}}
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,order=4
-	Tolerations *[]corev1.Toleration `json:"tolerations,omitempty"`
+	Tolerations *[]corev1.Toleration `json:"tolerations"`
 
 	// Specifies node affinity for scheduling the DaemonSet. Defaults to allowing scheduling on all nodes.
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,order=5
@@ -233,12 +213,4 @@ type FalconNodeSensorList struct {
 
 func init() {
 	SchemeBuilder.Register(&FalconNodeSensor{}, &FalconNodeSensorList{})
-}
-
-func (sensor FalconNodeSensor) GetTolerations() *[]corev1.Toleration {
-	if sensor.Spec.Node.Tolerations == nil {
-		return &NodeDefaultTolerations
-	}
-
-	return sensor.Spec.Node.Tolerations
 }

--- a/api/falcon/v1alpha1/falconnodesensor_types.go
+++ b/api/falcon/v1alpha1/falconnodesensor_types.go
@@ -6,6 +6,26 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+var (
+	NodeDefaultTolerations = []corev1.Toleration{
+		{
+			Key:      "node-role.kubernetes.io/master",
+			Operator: "Exists",
+			Effect:   "NoSchedule",
+		},
+		{
+			Key:      "node-role.kubernetes.io/control-plane",
+			Operator: "Exists",
+			Effect:   "NoSchedule",
+		},
+		{
+			Key:      "node-role.kubernetes.io/infra",
+			Operator: "Exists",
+			Effect:   "NoSchedule",
+		},
+	}
+)
+
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
@@ -44,7 +64,7 @@ type FalconNodeSensorConfig struct {
 	// Specifies tolerations for custom taints. Defaults to allowing scheduling on all nodes.
 	// +kubebuilder:default:={{key: "node-role.kubernetes.io/master", operator: "Exists", effect: "NoSchedule"}, {key: "node-role.kubernetes.io/control-plane", operator: "Exists", effect: "NoSchedule"}, {key: "node-role.kubernetes.io/infra", operator: "Exists", effect: "NoSchedule"}}
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,order=4
-	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
+	Tolerations *[]corev1.Toleration `json:"tolerations,omitempty"`
 
 	// Specifies node affinity for scheduling the DaemonSet. Defaults to allowing scheduling on all nodes.
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,order=5
@@ -213,4 +233,12 @@ type FalconNodeSensorList struct {
 
 func init() {
 	SchemeBuilder.Register(&FalconNodeSensor{}, &FalconNodeSensorList{})
+}
+
+func (sensor FalconNodeSensor) GetTolerations() *[]corev1.Toleration {
+	if sensor.Spec.Node.Tolerations == nil {
+		return &NodeDefaultTolerations
+	}
+
+	return sensor.Spec.Node.Tolerations
 }

--- a/api/falcon/v1alpha1/zz_generated.deepcopy.go
+++ b/api/falcon/v1alpha1/zz_generated.deepcopy.go
@@ -1057,9 +1057,13 @@ func (in *FalconNodeSensorConfig) DeepCopyInto(out *FalconNodeSensorConfig) {
 	*out = *in
 	if in.Tolerations != nil {
 		in, out := &in.Tolerations, &out.Tolerations
-		*out = make([]corev1.Toleration, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
+		*out = new([]corev1.Toleration)
+		if **in != nil {
+			in, out := *in, *out
+			*out = make([]corev1.Toleration, len(*in))
+			for i := range *in {
+				(*in)[i].DeepCopyInto(&(*out)[i])
+			}
 		}
 	}
 	in.NodeAffinity.DeepCopyInto(&out.NodeAffinity)

--- a/docs/src/resources/node.md.tmpl
+++ b/docs/src/resources/node.md.tmpl
@@ -69,6 +69,9 @@ spec:
 | node.disableCleanup                 | (optional) Cleans up `/opt/CrowdStrike` on the nodes by deleting the files and directory.                                                 |
 | node.version                        | (optional) Enforce particular Falcon Sensor version to be installed (example: "6.35", "6.35.0-13207")                                     |
 
+> [!IMPORTANT]
+> node.tolerations will be appended to the existing tolerations for the daemonset due to the GKE Autopilot allowing users to manage Tolerations directly in the console. See documentation here: https://cloud.google.com/kubernetes-engine/docs/how-to/workload-separation. Removing Tolerations from an existing daemonset requires a redeploy of the FalconNodeSensor manifest.
+
 #### Falcon Sensor Settings
 | Spec                                | Description                                                                                                                                                                |
 | :---------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/internal/controller/assets/daemonset.go
+++ b/internal/controller/assets/daemonset.go
@@ -213,7 +213,7 @@ func Daemonset(dsName, image, serviceAccount string, node *falconv1alpha1.Falcon
 					// NodeSelector is set to linux until windows containers are supported for the Falcon sensor
 					NodeSelector:                  common.NodeSelector,
 					Affinity:                      nodeAffinity(node),
-					Tolerations:                   *node.GetTolerations(),
+					Tolerations:                   *node.Spec.Node.Tolerations,
 					HostPID:                       hostpid,
 					HostIPC:                       hostipc,
 					HostNetwork:                   hostnetwork,
@@ -304,7 +304,7 @@ func RemoveNodeDirDaemonset(dsName, image, serviceAccount string, node *falconv1
 					// NodeSelector is set to linux until windows containers are supported for the Falcon sensor
 					NodeSelector:                  common.NodeSelector,
 					Affinity:                      nodeAffinity(node),
-					Tolerations:                   *node.GetTolerations(),
+					Tolerations:                   *node.Spec.Node.Tolerations,
 					HostPID:                       hostpid,
 					TerminationGracePeriodSeconds: getTermGracePeriod(node),
 					ImagePullSecrets:              pullSecrets(node),

--- a/internal/controller/assets/daemonset.go
+++ b/internal/controller/assets/daemonset.go
@@ -213,7 +213,7 @@ func Daemonset(dsName, image, serviceAccount string, node *falconv1alpha1.Falcon
 					// NodeSelector is set to linux until windows containers are supported for the Falcon sensor
 					NodeSelector:                  common.NodeSelector,
 					Affinity:                      nodeAffinity(node),
-					Tolerations:                   node.Spec.Node.Tolerations,
+					Tolerations:                   *node.GetTolerations(),
 					HostPID:                       hostpid,
 					HostIPC:                       hostipc,
 					HostNetwork:                   hostnetwork,
@@ -304,7 +304,7 @@ func RemoveNodeDirDaemonset(dsName, image, serviceAccount string, node *falconv1
 					// NodeSelector is set to linux until windows containers are supported for the Falcon sensor
 					NodeSelector:                  common.NodeSelector,
 					Affinity:                      nodeAffinity(node),
-					Tolerations:                   node.Spec.Node.Tolerations,
+					Tolerations:                   *node.GetTolerations(),
 					HostPID:                       hostpid,
 					TerminationGracePeriodSeconds: getTermGracePeriod(node),
 					ImagePullSecrets:              pullSecrets(node),

--- a/internal/controller/assets/daemonset_test.go
+++ b/internal/controller/assets/daemonset_test.go
@@ -188,7 +188,23 @@ func TestDaemonset(t *testing.T) {
 	falconNode.Name = "test"
 	image := "testImage"
 	dsName := "test-DaemonSet"
-	falconNode.Spec.Node.Tolerations = falconNode.GetTolerations()
+	falconNode.Spec.Node.Tolerations = &[]corev1.Toleration{
+		{
+			Key:      "node-role.kubernetes.io/master",
+			Operator: "Exists",
+			Effect:   "NoSchedule",
+		},
+		{
+			Key:      "node-role.kubernetes.io/control-plane",
+			Operator: "Exists",
+			Effect:   "NoSchedule",
+		},
+		{
+			Key:      "node-role.kubernetes.io/infra",
+			Operator: "Exists",
+			Effect:   "NoSchedule",
+		},
+	}
 
 	privileged := true
 	escalation := true
@@ -220,7 +236,7 @@ func TestDaemonset(t *testing.T) {
 					// NodeSelector is set to linux until windows containers are supported for the Falcon sensor
 					NodeSelector:                  common.NodeSelector,
 					Affinity:                      nodeAffinity(&falconNode),
-					Tolerations:                   falconv1alpha1.NodeDefaultTolerations,
+					Tolerations:                   *falconNode.Spec.Node.Tolerations,
 					HostPID:                       hostpid,
 					HostIPC:                       hostipc,
 					HostNetwork:                   hostnetwork,
@@ -299,7 +315,23 @@ func TestRemoveNodeDirDaemonset(t *testing.T) {
 	falconNode.Name = "test"
 	image := "testImage"
 	dsName := "test-DaemonSet"
-	falconNode.Spec.Node.Tolerations = falconNode.GetTolerations()
+	falconNode.Spec.Node.Tolerations = &[]corev1.Toleration{
+		{
+			Key:      "node-role.kubernetes.io/master",
+			Operator: "Exists",
+			Effect:   "NoSchedule",
+		},
+		{
+			Key:      "node-role.kubernetes.io/control-plane",
+			Operator: "Exists",
+			Effect:   "NoSchedule",
+		},
+		{
+			Key:      "node-role.kubernetes.io/infra",
+			Operator: "Exists",
+			Effect:   "NoSchedule",
+		},
+	}
 
 	privileged := true
 	nonPrivileged := false
@@ -326,25 +358,9 @@ func TestRemoveNodeDirDaemonset(t *testing.T) {
 				},
 				Spec: corev1.PodSpec{
 					// NodeSelector is set to linux until windows containers are supported for the Falcon sensor
-					NodeSelector: common.NodeSelector,
-					Affinity:     nodeAffinity(&falconNode),
-					Tolerations: []corev1.Toleration{
-						{
-							Key:      "node-role.kubernetes.io/master",
-							Operator: "Exists",
-							Effect:   "NoSchedule",
-						},
-						{
-							Key:      "node-role.kubernetes.io/control-plane",
-							Operator: "Exists",
-							Effect:   "NoSchedule",
-						},
-						{
-							Key:      "node-role.kubernetes.io/infra",
-							Operator: "Exists",
-							Effect:   "NoSchedule",
-						},
-					},
+					NodeSelector:                  common.NodeSelector,
+					Affinity:                      nodeAffinity(&falconNode),
+					Tolerations:                   *falconNode.Spec.Node.Tolerations,
 					HostPID:                       hostpid,
 					TerminationGracePeriodSeconds: getTermGracePeriod(&falconNode),
 					ImagePullSecrets:              pullSecrets(&falconNode),

--- a/internal/controller/assets/daemonset_test.go
+++ b/internal/controller/assets/daemonset_test.go
@@ -188,6 +188,7 @@ func TestDaemonset(t *testing.T) {
 	falconNode.Name = "test"
 	image := "testImage"
 	dsName := "test-DaemonSet"
+	falconNode.Spec.Node.Tolerations = falconNode.GetTolerations()
 
 	privileged := true
 	escalation := true
@@ -219,7 +220,7 @@ func TestDaemonset(t *testing.T) {
 					// NodeSelector is set to linux until windows containers are supported for the Falcon sensor
 					NodeSelector:                  common.NodeSelector,
 					Affinity:                      nodeAffinity(&falconNode),
-					Tolerations:                   falconNode.Spec.Node.Tolerations,
+					Tolerations:                   falconv1alpha1.NodeDefaultTolerations,
 					HostPID:                       hostpid,
 					HostIPC:                       hostipc,
 					HostNetwork:                   hostnetwork,
@@ -298,6 +299,7 @@ func TestRemoveNodeDirDaemonset(t *testing.T) {
 	falconNode.Name = "test"
 	image := "testImage"
 	dsName := "test-DaemonSet"
+	falconNode.Spec.Node.Tolerations = falconNode.GetTolerations()
 
 	privileged := true
 	nonPrivileged := false
@@ -324,9 +326,25 @@ func TestRemoveNodeDirDaemonset(t *testing.T) {
 				},
 				Spec: corev1.PodSpec{
 					// NodeSelector is set to linux until windows containers are supported for the Falcon sensor
-					NodeSelector:                  common.NodeSelector,
-					Affinity:                      nodeAffinity(&falconNode),
-					Tolerations:                   falconNode.Spec.Node.Tolerations,
+					NodeSelector: common.NodeSelector,
+					Affinity:     nodeAffinity(&falconNode),
+					Tolerations: []corev1.Toleration{
+						{
+							Key:      "node-role.kubernetes.io/master",
+							Operator: "Exists",
+							Effect:   "NoSchedule",
+						},
+						{
+							Key:      "node-role.kubernetes.io/control-plane",
+							Operator: "Exists",
+							Effect:   "NoSchedule",
+						},
+						{
+							Key:      "node-role.kubernetes.io/infra",
+							Operator: "Exists",
+							Effect:   "NoSchedule",
+						},
+					},
 					HostPID:                       hostpid,
 					TerminationGracePeriodSeconds: getTermGracePeriod(&falconNode),
 					ImagePullSecrets:              pullSecrets(&falconNode),

--- a/internal/controller/falcon_node/falconnodesensor_controller.go
+++ b/internal/controller/falcon_node/falconnodesensor_controller.go
@@ -638,13 +638,13 @@ func updateDaemonSetContainerProxy(ds *appsv1.DaemonSet, logger logr.Logger) boo
 // If an update is needed, this will update the tolerations from the given DaemonSet
 func (r *FalconNodeSensorReconciler) updateDaemonSetTolerations(ctx context.Context, ds *appsv1.DaemonSet, nodesensor *falconv1alpha1.FalconNodeSensor, logger logr.Logger) (bool, error) {
 	tolerations := &ds.Spec.Template.Spec.Tolerations
-	origTolerations := nodesensor.Spec.Node.Tolerations
-	tolerationsUpdate := !equality.Semantic.DeepEqual(*tolerations, origTolerations)
+	origTolerations := nodesensor.GetTolerations()
+	tolerationsUpdate := !equality.Semantic.DeepEqual(*tolerations, *origTolerations)
 	if tolerationsUpdate {
 		logger.Info("Updating FalconNodeSensor DaemonSet Tolerations")
-		mergedTolerations := k8s_utils.MergeTolerations(*tolerations, origTolerations)
+		mergedTolerations := k8s_utils.MergeTolerations(*tolerations, *origTolerations)
 		*tolerations = mergedTolerations
-		nodesensor.Spec.Node.Tolerations = mergedTolerations
+		nodesensor.Spec.Node.Tolerations = &mergedTolerations
 
 		if err := r.Update(ctx, nodesensor); err != nil {
 			logger.Error(err, "Failed to update FalconNodeSensor Tolerations")

--- a/internal/controller/falcon_node/falconnodesensor_controller.go
+++ b/internal/controller/falcon_node/falconnodesensor_controller.go
@@ -638,7 +638,7 @@ func updateDaemonSetContainerProxy(ds *appsv1.DaemonSet, logger logr.Logger) boo
 // If an update is needed, this will update the tolerations from the given DaemonSet
 func (r *FalconNodeSensorReconciler) updateDaemonSetTolerations(ctx context.Context, ds *appsv1.DaemonSet, nodesensor *falconv1alpha1.FalconNodeSensor, logger logr.Logger) (bool, error) {
 	tolerations := &ds.Spec.Template.Spec.Tolerations
-	origTolerations := nodesensor.GetTolerations()
+	origTolerations := nodesensor.Spec.Node.Tolerations
 	tolerationsUpdate := !equality.Semantic.DeepEqual(*tolerations, *origTolerations)
 	if tolerationsUpdate {
 		logger.Info("Updating FalconNodeSensor DaemonSet Tolerations")


### PR DESCRIPTION
This fixes the issue where an empty list for node.tolerations would change to the default tolerations after the multiple requeues required during the initial deployment of FalconNodeSensor