### PR TITLE
Fix FalconNodeSensor defaults

### DIFF
--- a/api/falcon/v1alpha1/falconnodesensor_types.go
+++ b/api/falcon/v1alpha1/falconnodesensor_types.go
@@ -23,9 +23,11 @@ type FalconNodeSensorSpec struct {
 	InstallNamespace string `json:"installNamespace,omitempty"`
 
 	// Various configuration for DaemonSet Deployment
+	// +kubebuilder:default:={imagePullPolicy: "Always"}
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="DaemonSet Configuration",order=3
 	Node FalconNodeSensorConfig `json:"node,omitempty"`
 
+	// +kubebuilder:default:={apd: false, trace: "none"}
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Falcon Sensor Configuration",order=2
 	Falcon FalconSensor `json:"falcon,omitempty"`
 
@@ -66,6 +68,7 @@ type FalconNodeSensorConfig struct {
 	ImagePullSecrets []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
 
 	// Type of DaemonSet update. Can be "RollingUpdate" or "OnDelete". Default is RollingUpdate.
+	// +kubebuilder:default={type: "RollingUpdate"}
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="DaemonSet Update Strategy",order=6
 	DSUpdateStrategy FalconNodeUpdateStrategy `json:"updateStrategy,omitempty"`
 

--- a/config/crd/bases/falcon.crowdstrike.com_falconnodesensors.yaml
+++ b/config/crd/bases/falcon.crowdstrike.com_falconnodesensors.yaml
@@ -44,6 +44,9 @@ spec:
             description: FalconNodeSensorSpec defines the desired state of FalconNodeSensor
             properties:
               falcon:
+                default:
+                  apd: false
+                  trace: none
                 description: CrowdStrike Falcon Sensor configuration settings.
                 properties:
                   apd:
@@ -136,6 +139,8 @@ spec:
                   are deployed.
                 type: string
               node:
+                default:
+                  imagePullPolicy: Always
                 description: Various configuration for DaemonSet Deployment
                 properties:
                   advanced:
@@ -542,6 +547,8 @@ spec:
                       type: object
                     type: array
                   updateStrategy:
+                    default:
+                      type: RollingUpdate
                     description: Type of DaemonSet update. Can be "RollingUpdate"
                       or "OnDelete". Default is RollingUpdate.
                     properties:

--- a/deploy/falcon-operator.yaml
+++ b/deploy/falcon-operator.yaml
@@ -3133,6 +3133,9 @@ spec:
             description: FalconNodeSensorSpec defines the desired state of FalconNodeSensor
             properties:
               falcon:
+                default:
+                  apd: false
+                  trace: none
                 description: CrowdStrike Falcon Sensor configuration settings.
                 properties:
                   apd:
@@ -3225,6 +3228,8 @@ spec:
                   are deployed.
                 type: string
               node:
+                default:
+                  imagePullPolicy: Always
                 description: Various configuration for DaemonSet Deployment
                 properties:
                   advanced:
@@ -3631,6 +3636,8 @@ spec:
                       type: object
                     type: array
                   updateStrategy:
+                    default:
+                      type: RollingUpdate
                     description: Type of DaemonSet update. Can be "RollingUpdate"
                       or "OnDelete". Default is RollingUpdate.
                     properties:


### PR DESCRIPTION
This adds the missing default markers to accommodated for nested objects within the FalconNodeSensor Spec. 
Operator log output from a `Get()` to the API when starting reconciliation for a new deployment when only `falcon_api` is set in the Spec: 
```
{
    "controller": "falconnodesensor",
    "controllerGroup": "falcon.crowdstrike.com",
    "controllerKind": "FalconNodeSensor",
    "FalconNodeSensor": {
        "name": "falcon-node-sensor"
    },
    "namespace": "",
    "name": "falcon-node-sensor",
    "reconcileID": "1a539e00-6d1c-45c6-b1b8-a4f11c1c0039",
    "nodesensor.Spec": {
        "installNamespace": "falcon-system",
        "node": {
            "tolerations": [
                {
                    "key": "node-role.kubernetes.io/master",
                    "operator": "Exists",
                    "effect": "NoSchedule"
                },
                {
                    "key": "node-role.kubernetes.io/control-plane",
                    "operator": "Exists",
                    "effect": "NoSchedule"
                },
                {
                    "key": "node-role.kubernetes.io/infra",
                    "operator": "Exists",
                    "effect": "NoSchedule"
                }
            ],
            "nodeAffinity": {},
            "imagePullPolicy": "Always",
            "updateStrategy": {
                "type": "RollingUpdate",
                "rollingUpdate": {}
            },
            "terminationGracePeriod": 30,
            "serviceAccount": {},
            "disableCleanup": false,
            "resources": {
                "limits": {},
                "requests": {}
            },
            "backend": "bpf",
            "gke": {},
            "priorityClass": {},
            "advanced": {}
        },
        "falcon": {
            "apd": false,
            "trace": "none"
        },
        "falcon_api": {
            "cloud_region": "autodiscover",
            "client_id": "CLIENT_ID",
            "client_secret": "CLIENT_SECRET"
        }
    }
}
```