### PR TITLE
fix: prevent e2e test failures caused by node sensor cleanup

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -21,7 +21,9 @@ import (
 
 // constant parts of the file
 const (
-	namespace = "falcon-operator-system"
+	namespace         = "falcon-operator-system"
+	defaultTimeout    = 2 * time.Minute
+	defaultPollPeriod = time.Second
 )
 
 var _ = Describe("falcon", Ordered, func() {
@@ -46,7 +48,7 @@ var _ = Describe("falcon", Ordered, func() {
 
 	AfterAll(func() {
 		By("removing manager namespace")
-		cmd := exec.Command("kubectl", "create", "ns", namespace)
+		cmd := exec.Command("kubectl", "delete", "ns", namespace)
 		_, _ = utils.Run(cmd)
 	})
 
@@ -117,7 +119,7 @@ var _ = Describe("falcon", Ordered, func() {
 				}
 				return nil
 			}
-			EventuallyWithOffset(1, verifyControllerUp, time.Minute, time.Second).Should(Succeed())
+			EventuallyWithOffset(1, verifyControllerUp, defaultTimeout, defaultPollPeriod).Should(Succeed())
 
 		})
 	})
@@ -153,7 +155,7 @@ var _ = Describe("falcon", Ordered, func() {
 					"./config/samples/falcon_v1alpha1_falconnodesensor.yaml"), "-n", namespace)
 				_, err := utils.Run(cmd)
 				return err
-			}, time.Minute, time.Second).Should(Succeed())
+			}, defaultTimeout, defaultPollPeriod).Should(Succeed())
 
 			By("validating that pod(s) status.phase=Running")
 			getFalconNodeSensorPodStatus := func() error {
@@ -169,7 +171,7 @@ var _ = Describe("falcon", Ordered, func() {
 				}
 				return nil
 			}
-			EventuallyWithOffset(1, getFalconNodeSensorPodStatus, time.Minute, time.Second).Should(Succeed())
+			EventuallyWithOffset(1, getFalconNodeSensorPodStatus, defaultTimeout, defaultPollPeriod).Should(Succeed())
 
 			By("validating that the status of the custom resource created is updated or not")
 			getStatus := func() error {
@@ -185,7 +187,7 @@ var _ = Describe("falcon", Ordered, func() {
 				}
 				return nil
 			}
-			Eventually(getStatus, time.Minute, time.Second).Should(Succeed())
+			Eventually(getStatus, defaultTimeout, defaultPollPeriod).Should(Succeed())
 		})
 	})
 
@@ -199,7 +201,7 @@ var _ = Describe("falcon", Ordered, func() {
 					"./config/samples/falcon_v1alpha1_falconnodesensor.yaml"), "-n", namespace)
 				_, err := utils.Run(cmd)
 				return err
-			}, time.Minute, time.Second).Should(Succeed())
+			}, defaultTimeout, defaultPollPeriod).Should(Succeed())
 
 			By("validating that pod(s) status.phase!=Running")
 			getFalconNodeSensorPodStatus := func() error {
@@ -215,104 +217,7 @@ var _ = Describe("falcon", Ordered, func() {
 				}
 				return nil
 			}
-			EventuallyWithOffset(1, getFalconNodeSensorPodStatus, time.Minute, time.Second).Should(Succeed())
-		})
-	})
-
-	Context("Falcon Sidecar Sensor", func() {
-		It("should deploy successfully", func() {
-			projectDir, _ := utils.GetProjectDir()
-
-			var falconClientID = ""
-			var falconClientSecret = ""
-			if clientID, ok := os.LookupEnv("FALCON_CLIENT_ID"); ok {
-				falconClientID = clientID
-			}
-
-			if clientSecret, ok := os.LookupEnv("FALCON_CLIENT_SECRET"); ok {
-				falconClientSecret = clientSecret
-			}
-
-			if falconClientID != "" && falconClientSecret != "" {
-				err := utils.ReplaceInFile(filepath.Join(projectDir,
-					"./config/samples/falcon_v1alpha1_falconcontainer.yaml"),
-					"client_id: PLEASE_FILL_IN", fmt.Sprintf("client_id: %s", falconClientID))
-				ExpectWithOffset(1, err).NotTo(HaveOccurred())
-				err = utils.ReplaceInFile(filepath.Join(projectDir,
-					"./config/samples/falcon_v1alpha1_falconcontainer.yaml"),
-					"client_secret: PLEASE_FILL_IN", fmt.Sprintf("client_secret: %s", falconClientSecret))
-				ExpectWithOffset(1, err).NotTo(HaveOccurred())
-			}
-
-			By("creating an instance of the FalconContainer Operand(CR)")
-			EventuallyWithOffset(1, func() error {
-				cmd := exec.Command("kubectl", "apply", "-f", filepath.Join(projectDir,
-					"./config/samples/falcon_v1alpha1_falconcontainer.yaml"), "-n", namespace)
-				_, err := utils.Run(cmd)
-				return err
-			}, time.Minute, time.Second).Should(Succeed())
-
-			By("validating that pod(s) status.phase=Running")
-			getFalconNodeSensorPodStatus := func() error {
-				cmd := exec.Command("kubectl", "get",
-					"pods", "-A", "-l", "crowdstrike.com/component=container_sensor",
-					"-o", "jsonpath={.items[*].status}", "-n", namespace,
-				)
-				status, err := utils.Run(cmd)
-				fmt.Println(string(status))
-				ExpectWithOffset(2, err).NotTo(HaveOccurred())
-				if !strings.Contains(string(status), "\"phase\":\"Running\"") {
-					return fmt.Errorf(" pod in %s status", status)
-				}
-				return nil
-			}
-			EventuallyWithOffset(1, getFalconNodeSensorPodStatus, time.Minute, time.Second).Should(Succeed())
-
-			By("validating that the status of the custom resource created is updated or not")
-			getStatus := func() error {
-				cmd := exec.Command("kubectl", "get", "falconcontainer",
-					"falcon-sidecar-sensor", "-A", "-o", "jsonpath={.status.conditions}",
-					"-n", namespace,
-				)
-				status, err := utils.Run(cmd)
-				fmt.Println(string(status))
-				ExpectWithOffset(2, err).NotTo(HaveOccurred())
-				if !strings.Contains(string(status), "Success") {
-					return fmt.Errorf("status condition with type Success should be set")
-				}
-				return nil
-			}
-			Eventually(getStatus, time.Minute, time.Second).Should(Succeed())
-		})
-	})
-
-	Context("Falcon Sidecar Sensor", func() {
-		It("should cleanup successfully", func() {
-			projectDir, _ := utils.GetProjectDir()
-
-			By("deleting an instance of the FalconContainer Operand(CR)")
-			EventuallyWithOffset(1, func() error {
-				cmd := exec.Command("kubectl", "delete", "-f", filepath.Join(projectDir,
-					"./config/samples/falcon_v1alpha1_falconcontainer.yaml"), "-n", namespace)
-				_, err := utils.Run(cmd)
-				return err
-			}, time.Minute, time.Second).Should(Succeed())
-
-			By("validating that pod(s) status.phase!=Running")
-			getFalconNodeSensorPodStatus := func() error {
-				cmd := exec.Command("kubectl", "get",
-					"pods", "-A", "-l", "crowdstrike.com/component=container_sensor", "--field-selector=status.phase=Running",
-					"-o", "jsonpath={.items[*].status}", "-n", namespace,
-				)
-				status, err := utils.Run(cmd)
-				fmt.Println(string(status))
-				ExpectWithOffset(2, err).NotTo(HaveOccurred())
-				if len(status) > 0 {
-					return fmt.Errorf("falcon-sidecar-sensor pod in %s status", status)
-				}
-				return nil
-			}
-			EventuallyWithOffset(1, getFalconNodeSensorPodStatus, time.Minute, time.Second).Should(Succeed())
+			EventuallyWithOffset(1, getFalconNodeSensorPodStatus, defaultTimeout, defaultPollPeriod).Should(Succeed())
 		})
 	})
 
@@ -347,7 +252,7 @@ var _ = Describe("falcon", Ordered, func() {
 					"./config/samples/falcon_v1alpha1_falconadmission.yaml"), "-n", namespace)
 				_, err := utils.Run(cmd)
 				return err
-			}, time.Minute, time.Second).Should(Succeed())
+			}, defaultTimeout, defaultPollPeriod).Should(Succeed())
 
 			By("validating that pod(s) status.phase=Running")
 			getFalconSidecarPodStatus := func() error {
@@ -363,7 +268,7 @@ var _ = Describe("falcon", Ordered, func() {
 				}
 				return nil
 			}
-			EventuallyWithOffset(1, getFalconSidecarPodStatus, time.Minute, time.Second).Should(Succeed())
+			EventuallyWithOffset(1, getFalconSidecarPodStatus, defaultTimeout, defaultPollPeriod).Should(Succeed())
 
 			By("validating that the status of the custom resource created is updated or not")
 			getStatus := func() error {
@@ -379,7 +284,7 @@ var _ = Describe("falcon", Ordered, func() {
 				}
 				return nil
 			}
-			Eventually(getStatus, time.Minute, time.Second).Should(Succeed())
+			Eventually(getStatus, defaultTimeout, defaultPollPeriod).Should(Succeed())
 		})
 	})
 
@@ -393,7 +298,7 @@ var _ = Describe("falcon", Ordered, func() {
 					"./config/samples/falcon_v1alpha1_falconadmission.yaml"), "-n", namespace)
 				_, err := utils.Run(cmd)
 				return err
-			}, time.Minute, time.Second).Should(Succeed())
+			}, defaultTimeout, defaultPollPeriod).Should(Succeed())
 
 			By("validating that pod(s) status.phase!=Running")
 			getFalconAdmissionPodStatus := func() error {
@@ -409,7 +314,104 @@ var _ = Describe("falcon", Ordered, func() {
 				}
 				return nil
 			}
-			EventuallyWithOffset(1, getFalconAdmissionPodStatus, time.Minute, time.Second).Should(Succeed())
+			EventuallyWithOffset(1, getFalconAdmissionPodStatus, defaultTimeout, defaultPollPeriod).Should(Succeed())
+		})
+	})
+
+	Context("Falcon Sidecar Sensor", func() {
+		It("should deploy successfully", func() {
+			projectDir, _ := utils.GetProjectDir()
+
+			var falconClientID = ""
+			var falconClientSecret = ""
+			if clientID, ok := os.LookupEnv("FALCON_CLIENT_ID"); ok {
+				falconClientID = clientID
+			}
+
+			if clientSecret, ok := os.LookupEnv("FALCON_CLIENT_SECRET"); ok {
+				falconClientSecret = clientSecret
+			}
+
+			if falconClientID != "" && falconClientSecret != "" {
+				err := utils.ReplaceInFile(filepath.Join(projectDir,
+					"./config/samples/falcon_v1alpha1_falconcontainer.yaml"),
+					"client_id: PLEASE_FILL_IN", fmt.Sprintf("client_id: %s", falconClientID))
+				ExpectWithOffset(1, err).NotTo(HaveOccurred())
+				err = utils.ReplaceInFile(filepath.Join(projectDir,
+					"./config/samples/falcon_v1alpha1_falconcontainer.yaml"),
+					"client_secret: PLEASE_FILL_IN", fmt.Sprintf("client_secret: %s", falconClientSecret))
+				ExpectWithOffset(1, err).NotTo(HaveOccurred())
+			}
+
+			By("creating an instance of the FalconContainer Operand(CR)")
+			EventuallyWithOffset(1, func() error {
+				cmd := exec.Command("kubectl", "apply", "-f", filepath.Join(projectDir,
+					"./config/samples/falcon_v1alpha1_falconcontainer.yaml"), "-n", namespace)
+				_, err := utils.Run(cmd)
+				return err
+			}, defaultTimeout, defaultPollPeriod).Should(Succeed())
+
+			By("validating that pod(s) status.phase=Running")
+			getFalconNodeSensorPodStatus := func() error {
+				cmd := exec.Command("kubectl", "get",
+					"pods", "-A", "-l", "crowdstrike.com/component=container_sensor",
+					"-o", "jsonpath={.items[*].status}", "-n", namespace,
+				)
+				status, err := utils.Run(cmd)
+				fmt.Println(string(status))
+				ExpectWithOffset(2, err).NotTo(HaveOccurred())
+				if !strings.Contains(string(status), "\"phase\":\"Running\"") {
+					return fmt.Errorf(" pod in %s status", status)
+				}
+				return nil
+			}
+			EventuallyWithOffset(1, getFalconNodeSensorPodStatus, defaultTimeout, defaultPollPeriod).Should(Succeed())
+
+			By("validating that the status of the custom resource created is updated or not")
+			getStatus := func() error {
+				cmd := exec.Command("kubectl", "get", "falconcontainer",
+					"falcon-sidecar-sensor", "-A", "-o", "jsonpath={.status.conditions}",
+					"-n", namespace,
+				)
+				status, err := utils.Run(cmd)
+				fmt.Println(string(status))
+				ExpectWithOffset(2, err).NotTo(HaveOccurred())
+				if !strings.Contains(string(status), "Success") {
+					return fmt.Errorf("status condition with type Success should be set")
+				}
+				return nil
+			}
+			Eventually(getStatus, defaultTimeout, defaultPollPeriod).Should(Succeed())
+		})
+	})
+
+	Context("Falcon Sidecar Sensor", func() {
+		It("should cleanup successfully", func() {
+			projectDir, _ := utils.GetProjectDir()
+
+			By("deleting an instance of the FalconContainer Operand(CR)")
+			EventuallyWithOffset(1, func() error {
+				cmd := exec.Command("kubectl", "delete", "-f", filepath.Join(projectDir,
+					"./config/samples/falcon_v1alpha1_falconcontainer.yaml"), "-n", namespace)
+				_, err := utils.Run(cmd)
+				return err
+			}, defaultTimeout, defaultPollPeriod).Should(Succeed())
+
+			By("validating that pod(s) status.phase!=Running")
+			getFalconNodeSensorPodStatus := func() error {
+				cmd := exec.Command("kubectl", "get",
+					"pods", "-A", "-l", "crowdstrike.com/component=container_sensor", "--field-selector=status.phase=Running",
+					"-o", "jsonpath={.items[*].status}", "-n", namespace,
+				)
+				status, err := utils.Run(cmd)
+				fmt.Println(string(status))
+				ExpectWithOffset(2, err).NotTo(HaveOccurred())
+				if len(status) > 0 {
+					return fmt.Errorf("falcon-sidecar-sensor pod in %s status", status)
+				}
+				return nil
+			}
+			EventuallyWithOffset(1, getFalconNodeSensorPodStatus, defaultTimeout, defaultPollPeriod).Should(Succeed())
 		})
 	})
 })


### PR DESCRIPTION
- Flipping the order of tests to be node -> kac -> sidecar since the node cleanup pod would occasionally still be running when the sidecar would deploy.
- Updating the timeout to prevent the periodic failures caused by extended image pull times. 