### PR TITLE
fix: deployments to prevent endless reconciles

### DIFF
--- a/internal/controller/assets/mutatingwebhook.go
+++ b/internal/controller/assets/mutatingwebhook.go
@@ -53,6 +53,7 @@ func MutatingWebhook(name string, namespace string, webhookName string, caBundle
 					},
 				},
 				TimeoutSeconds: &timeoutSeconds,
+				ObjectSelector: &metav1.LabelSelector{},
 				NamespaceSelector: &metav1.LabelSelector{
 					MatchExpressions: []metav1.LabelSelectorRequirement{
 						{

--- a/internal/controller/assets/mutatingwebhook_test.go
+++ b/internal/controller/assets/mutatingwebhook_test.go
@@ -73,6 +73,7 @@ func testWebhook(disableNSInjection bool, falconContainer *falconv1alpha1.Falcon
 					},
 				},
 				TimeoutSeconds: &timeoutSeconds,
+				ObjectSelector: &metav1.LabelSelector{},
 				NamespaceSelector: &metav1.LabelSelector{
 					MatchExpressions: []metav1.LabelSelectorRequirement{
 						{

--- a/internal/controller/common/utils.go
+++ b/internal/controller/common/utils.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 
 	falconv1alpha1 "github.com/crowdstrike/falcon-operator/api/falcon/v1alpha1"
 	"github.com/go-logr/logr"
-	"golang.org/x/exp/slices"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -272,6 +272,8 @@ func GetRunningFalconNS(r client.Client, ctx context.Context) ([]string, error) 
 			falconNamespaces = append(falconNamespaces, pod.GetNamespace())
 		}
 	}
+
+	slices.Sort(falconNamespaces)
 
 	return falconNamespaces, nil
 }


### PR DESCRIPTION
- sorting the CS namespaces to prevent reconcile loops when multiple components are deployed simultaneously in KAC
- updating mutating webhook default to prevent container sensor reconcile loops.  