### PR TITLE
Fix: Add required OpenShift image labels

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.access.redhat.com/ubi8/go-toolset:1.22.9-2.1740072407 as builder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.22.9-2.1740072407 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 ARG VERSION
@@ -34,10 +34,19 @@ RUN GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -tags \
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM registry.access.redhat.com/ubi8-minimal:8.10-1179.1739286367
+ARG VERSION
 WORKDIR /
 COPY LICENSE licenses/
 COPY --from=builder /etc/pki /etc/pki
 COPY --from=builder /workspace/manager .
 USER 65532:65532
+
+LABEL name="falcon-operator" \      
+      vendor="CrowdStrike, Inc" \      
+      version="${VERSION}" \      
+      release="1" \      
+      summary="Crowdstrike Falcon Operator Controller" \
+      description="The CrowdStrike Falcon Operator installs CrowdStrike Falcon custom resources on a Kubernetes cluster." \              
+      maintainer="support@crowdstrike.com" 
 
 ENTRYPOINT ["/manager"]


### PR DESCRIPTION
Updating accommodate newly required image metadata: https://docs.redhat.com/en/documentation/red_hat_software_certification/2025/html/red_hat_openshift_software_certification_policy_guide/assembly-requirements-for-container-images_openshift-sw-cert-policy-introduction#con-image-metadata-requirements_openshift-sw-cert-policy-container-images 