### PR TITLE
Set the Falcon sensor cleanup node sleep time to infinity

### DIFF
--- a/pkg/common/common_test.go
+++ b/pkg/common/common_test.go
@@ -39,7 +39,7 @@ func TestInitCleanupArgs(t *testing.T) {
 }
 
 func TestCleanupSleep(t *testing.T) {
-	want := []string{"-c", "sleep 10"}
+	want := []string{"-c", "sleep infinity"}
 	if got := CleanupSleep(); !reflect.DeepEqual(got, want) {
 		t.Errorf("CleanupSleep() = %v, want %v", got, want)
 	}

--- a/pkg/common/funcs.go
+++ b/pkg/common/funcs.go
@@ -41,7 +41,7 @@ func InitCleanupArgs() []string {
 func CleanupSleep() []string {
 	return []string{
 		"-c",
-		"sleep 10",
+		"sleep infinity",
 	}
 }
 


### PR DESCRIPTION
The node cleanup DaemonSet cleans up a Falcon sensor installation in a pod init-container, with the pod container just doing a noop sleep for 10 seconds.

In clusters with a large number of nodes, it's possible that the cleanup DaemonSet runs to completion and enters CrashLoopBackOff on a particular node, before it has been deployed to all nodes.

By modifying the sleep time to infinity, the pods remain in the "Running" state instead of "CrashLoopBackOff".

See https://github.com/CrowdStrike/falcon-helm/pull/395 for more information.