### PR TITLE
docs: clarify support on ROSA Classic vs. HCP

### DIFF
--- a/docs/deployment/openshift/README.md
+++ b/docs/deployment/openshift/README.md
@@ -26,13 +26,13 @@ If you want to automate the deployment of the operator, the CLI method is recomm
 ### Managed OpenShift Considerations
 
 > [!IMPORTANT]
-> On managed OpenShift services (e.g. ROSA, ARO, RHOIC, OSD), Red Hat does not support running any workloads on control plane and infrastructure nodes (including OpenShift-certified operators like this one). For managed OpenShift services _only_, you must choose one of these deployment options:
+> On managed OpenShift services (e.g. ROSA Classic, ARO, RHOIC, OSD), Red Hat does not support running any workloads on control plane and infrastructure nodes (including OpenShift-certified operators like this one). For managed OpenShift services that provide access to control plane nodes _only_, you must choose one of these deployment options:
 >
 > 1. **Deploy the Falcon sensor only to worker nodes.** This introduces risk by not having visibility and protection on control plane and infrastructure nodes, but maintains full support from Red Hat Site Reliability Engineering (SRE). To do so, set `spec.node.tolerations: []` on `FalconNodeSensor`.
 >
 > 2. **Deploy the Falcon sensor to all nodes.** This provides full protection for the cluster, but may prevent Red Hat SRE from maintaining your service level agreement (SLA) for availability. We recommend working with your Red Hat account team to submit a support exception in this case. This is the default behavior of the operator, so no configuration is required. For more information, see the Red Hat support article [Running custom workloads in OSD/ROSA control plane or infra nodes](https://access.redhat.com/solutions/6972101).
 >
-> These constraints are specific to managed OpenShift services. The Falcon sensor is always supported on all node types for self-managed OpenShift clusters.
+> These constraints are specific to managed OpenShift services. ROSA with Hosted Control Planes (HCP) is not affected because it does not provide access to the control plane. The Falcon sensor is _always_ supported on _all_ node types for self-managed OpenShift clusters, regardless of whether they are running on-premises or in the cloud.
 
 ## Installing the operator through the Web Console (GUI)
 

--- a/docs/src/deployment/openshift/README.md
+++ b/docs/src/deployment/openshift/README.md
@@ -26,13 +26,13 @@ If you want to automate the deployment of the operator, the CLI method is recomm
 ### Managed OpenShift Considerations
 
 > [!IMPORTANT]
-> On managed OpenShift services (e.g. ROSA, ARO, RHOIC, OSD), Red Hat does not support running any workloads on control plane and infrastructure nodes (including OpenShift-certified operators like this one). For managed OpenShift services _only_, you must choose one of these deployment options:
+> On managed OpenShift services (e.g. ROSA Classic, ARO, RHOIC, OSD), Red Hat does not support running any workloads on control plane and infrastructure nodes (including OpenShift-certified operators like this one). For managed OpenShift services that provide access to control plane nodes _only_, you must choose one of these deployment options:
 >
 > 1. **Deploy the Falcon sensor only to worker nodes.** This introduces risk by not having visibility and protection on control plane and infrastructure nodes, but maintains full support from Red Hat Site Reliability Engineering (SRE). To do so, set `spec.node.tolerations: []` on `FalconNodeSensor`.
 >
 > 2. **Deploy the Falcon sensor to all nodes.** This provides full protection for the cluster, but may prevent Red Hat SRE from maintaining your service level agreement (SLA) for availability. We recommend working with your Red Hat account team to submit a support exception in this case. This is the default behavior of the operator, so no configuration is required. For more information, see the Red Hat support article [Running custom workloads in OSD/ROSA control plane or infra nodes](https://access.redhat.com/solutions/6972101).
 >
-> These constraints are specific to managed OpenShift services. The Falcon sensor is always supported on all node types for self-managed OpenShift clusters.
+> These constraints are specific to managed OpenShift services. ROSA with Hosted Control Planes (HCP) is not affected because it does not provide access to the control plane. The Falcon sensor is _always_ supported on _all_ node types for self-managed OpenShift clusters, regardless of whether they are running on-premises or in the cloud.
 
 ## Installing the operator through the Web Console (GUI)
 


### PR DESCRIPTION
ROSA HCP only shows worker nodes in the cluster, so we are always supported there.