### PR TITLE
refactor: fix e2e test namespace conflicts

### DIFF
--- a/config/samples/falcon_v1alpha1_falconadmission.yaml
+++ b/config/samples/falcon_v1alpha1_falconadmission.yaml
@@ -9,7 +9,7 @@ metadata:
     crowdstrike.com/name: falconadmission
     crowdstrike.com/part-of: Falcon
     crowdstrike.com/provider: crowdstrike
-  name: falcon-admission
+  name: falcon-kac
 spec:
   falcon_api:
     client_id: PLEASE_FILL_IN

--- a/config/samples/falcon_v1alpha1_falconcontainer-with-falcon-secret.yaml
+++ b/config/samples/falcon_v1alpha1_falconcontainer-with-falcon-secret.yaml
@@ -16,7 +16,7 @@ metadata:
     crowdstrike.com/name: falconcontainer
     crowdstrike.com/part-of: Falcon
     crowdstrike.com/provider: crowdstrike
-  name: falcon-sidecar-sensor
+  name: falcon-container-sensor
 spec:
   falconSecret:
     enabled: true

--- a/config/samples/falcon_v1alpha1_falconcontainer.yaml
+++ b/config/samples/falcon_v1alpha1_falconcontainer.yaml
@@ -16,7 +16,7 @@ metadata:
     crowdstrike.com/name: falconcontainer
     crowdstrike.com/part-of: Falcon
     crowdstrike.com/provider: crowdstrike
-  name: falcon-sidecar-sensor
+  name: falcon-container-sensor
 spec:
   falcon_api:
     client_id: PLEASE_FILL_IN

--- a/config/samples/falcon_v1alpha1_falconimageanalyzer-all-options.yaml
+++ b/config/samples/falcon_v1alpha1_falconimageanalyzer-all-options.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/part-of: falcon-operator
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: falcon-operator
-  name: falconimageanalyzer-sample
+  name: falcon-image-analyzer
 spec:
   falcon_api:
     client_id: PLEASE_FILL_IN

--- a/config/samples/falcon_v1alpha1_falconimageanalyzer.yaml
+++ b/config/samples/falcon_v1alpha1_falconimageanalyzer.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/part-of: falcon-operator
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: falcon-operator
-  name: falcon-iar
+  name: falcon-image-analyzer
 spec:
   falcon_api:
     client_id: PLEASE_FILL_IN

--- a/test/e2e/cr_config_test.go
+++ b/test/e2e/cr_config_test.go
@@ -1,0 +1,142 @@
+package e2e
+
+import (
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/crowdstrike/falcon-operator/test/utils"
+	//nolint:golint
+	//nolint:revive
+	. "github.com/onsi/ginkgo/v2"
+
+	//nolint:golint
+	//nolint:revive
+	. "github.com/onsi/gomega"
+)
+
+// crConfig holds the configuration parameters for each CRD.
+// It defines the basic metadata and namespace information needed for installation.
+// Ensure that fields are set to values that match the manifests found in the config/samples directory.
+type crConfig struct {
+	kind          string
+	namespace     string // InstallNamespace for the Spec
+	metadataName  string // The name of the resource expected in metadata.name
+	componentName string // Component name in the metadata.labels
+}
+type crOperation struct {
+	command string
+	action  string
+}
+
+var (
+	kacConfig = crConfig{
+		kind:          "FalconAdmission",
+		namespace:     "falcon-kac",
+		metadataName:  "falcon-kac",
+		componentName: "admission_controller",
+	}
+	iarConfig = crConfig{
+		kind:          "FalconImageAnalyzer",
+		namespace:     "falcon-iar",
+		metadataName:  "falcon-image-analyzer",
+		componentName: "admission_controller",
+	}
+	nodeConfig = crConfig{
+		kind:          "FalconNodeSensor",
+		namespace:     "falcon-system",
+		metadataName:  "falcon-node-sensor",
+		componentName: "kernel_sensor",
+	}
+	sidecarConfig = crConfig{
+		kind:          "FalconContainer",
+		namespace:     "falcon-system",
+		metadataName:  "falcon-container-sensor",
+		componentName: "container_sensor",
+	}
+	secretConfig = crConfig{
+		namespace: falconSecretNamespace,
+	}
+	falconDeploymentConfig = crConfig{
+		kind:         "FalconDeployment",
+		namespace:    namespace,
+		metadataName: "falcon-deployment",
+	}
+	projectDir, _ = utils.GetProjectDir()
+	crApply       = crOperation{command: "apply", action: "creating"}
+	crDelete      = crOperation{command: "delete", action: "deleting"}
+)
+
+func (cr crConfig) validateCrStatus() {
+	By("validating that the status of the custom resource created is updated or not")
+	getStatus := func() error {
+		cmd := exec.Command("kubectl", "get", strings.ToLower(cr.kind),
+			cr.metadataName, "-A", "-o", "jsonpath={.status.conditions}",
+			"-n", cr.namespace,
+		)
+		status, err := utils.Run(cmd)
+		fmt.Println(string(status))
+		ExpectWithOffset(2, err).NotTo(HaveOccurred())
+		if !strings.Contains(string(status), "Success") {
+			return fmt.Errorf("status condition with type Success should be set")
+		}
+		return nil
+	}
+	Eventually(getStatus, defaultTimeout, defaultPollPeriod).Should(Succeed())
+}
+
+func (cr crConfig) deleteNamespace() {
+	By(fmt.Sprintf("deleting namespace %s", cr.namespace))
+	deleteCmd := exec.Command("kubectl", "delete", "ns", cr.namespace)
+	_, err := utils.Run(deleteCmd)
+	ExpectWithOffset(2, err).NotTo(HaveOccurred())
+}
+
+func (cr crConfig) waitForNamespaceDeletion() {
+	By(fmt.Sprintf("waiting for %s namespace to be fully deleted", cr.namespace))
+	getNamespaceStatus := func() error {
+		cmd := exec.Command("kubectl", "get", "namespace")
+		status, err := utils.Run(cmd)
+		ExpectWithOffset(3, err).NotTo(HaveOccurred())
+		if strings.Contains(string(status), cr.namespace) {
+			return fmt.Errorf("%s namespace still exists", cr.namespace)
+		}
+		return nil
+	}
+	EventuallyWithOffset(2, getNamespaceStatus, defaultTimeout, defaultPollPeriod).Should(Succeed())
+}
+
+func (cr crConfig) validateRunningStatus(running bool) {
+	phase := "=Running"
+	if !running {
+		phase = "!=Running"
+	}
+
+	By("validating that pod(s) status.phase" + phase)
+	componentLabel := fmt.Sprintf("crowdstrike.com/component=%s", cr.componentName)
+	getFalconNodeSensorPodStatus := func() error {
+		cmd := exec.Command("kubectl", "get",
+			"pods", "-A", "-l", componentLabel, "--field-selector=status.phase=Running",
+			"-o", "jsonpath={.items[*].status}", "-n", cr.namespace,
+		)
+		status, err := utils.Run(cmd)
+		fmt.Println(string(status))
+		ExpectWithOffset(2, err).NotTo(HaveOccurred())
+		if (!running && len(status) > 0) || (running && !strings.Contains(string(status), "\"phase\":\"Running\"")) {
+			return fmt.Errorf("%s pod in %s status", cr.metadataName, status)
+		}
+		return nil
+	}
+	EventuallyWithOffset(1, getFalconNodeSensorPodStatus, defaultTimeout, defaultPollPeriod).Should(Succeed())
+}
+
+func (cr crConfig) manageCrdInstance(crCmd crOperation, manifest string) {
+	By(fmt.Sprintf("%s an instance of the %s Operand(CR)", crCmd.action, cr.kind))
+	EventuallyWithOffset(1, func() error {
+		cmd := exec.Command("kubectl", crCmd.command, "-f", filepath.Join(projectDir,
+			manifest), "-n", cr.namespace)
+		_, err := utils.Run(cmd)
+		return err
+	}, defaultTimeout, defaultPollPeriod).Should(Succeed())
+}

--- a/test/e2e/e2e_common_test.go
+++ b/test/e2e/e2e_common_test.go
@@ -1,0 +1,122 @@
+package e2e
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/crowdstrike/falcon-operator/test/utils"
+	//nolint:golint
+	//nolint:revive
+	. "github.com/onsi/ginkgo/v2"
+
+	//nolint:golint
+	//nolint:revive
+	. "github.com/onsi/gomega"
+)
+
+type tokenRequest struct {
+	Status struct {
+		Token string `json:"token"`
+	} `json:"status"`
+}
+
+func serviceAccountToken() (string, error) {
+	const tokenRequestRawString = `{
+		"apiVersion": "authentication.k8s.io/v1",
+		"kind": "TokenRequest"
+	}`
+
+	// Temporary file to store the token request
+	secretName := fmt.Sprintf("%s-token-request", serviceAccountName)
+	tokenRequestFile := filepath.Join("/tmp", secretName)
+	err := os.WriteFile(tokenRequestFile, []byte(tokenRequestRawString), os.FileMode(0o644))
+	if err != nil {
+		return "", err
+	}
+
+	var out string
+	verifyTokenCreation := func(g Gomega) {
+		// Execute kubectl command to create the token
+		cmd := exec.Command("kubectl", "create", "--raw", fmt.Sprintf(
+			"/api/v1/namespaces/%s/serviceaccounts/%s/token",
+			namespace,
+			serviceAccountName,
+		), "-f", tokenRequestFile)
+
+		output, err := cmd.CombinedOutput()
+		g.Expect(err).NotTo(HaveOccurred())
+
+		// Parse the JSON output to extract the token
+		var token tokenRequest
+		err = json.Unmarshal(output, &token)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		out = token.Status.Token
+	}
+	Eventually(verifyTokenCreation).Should(Succeed())
+
+	return out, err
+}
+
+// getMetricsOutput retrieves and returns the logs from the curl pod used to access the metrics endpoint.
+func getMetricsOutput() string {
+	By("getting the curl-metrics logs")
+	cmd := exec.Command("kubectl", "logs", "curl-metrics", "-n", namespace)
+	metricsOutput, err := utils.Run(cmd)
+	Expect(err).NotTo(HaveOccurred(), "Failed to retrieve logs from curl pod")
+	Expect(metricsOutput).To(ContainSubstring("< HTTP/1.1 200 OK"))
+	return string(metricsOutput)
+}
+
+func getCredentials() (client_id string, client_secret string) {
+	if clientID, ok := os.LookupEnv("FALCON_CLIENT_ID"); ok {
+		client_id = clientID
+	}
+
+	if clientSecret, ok := os.LookupEnv("FALCON_CLIENT_SECRET"); ok {
+		client_secret = clientSecret
+	}
+	return client_id, client_secret
+}
+
+func updateManifestApiCreds(manifest string) {
+	falconClientID, falconClientSecret := getCredentials()
+
+	if falconClientID != "" && falconClientSecret != "" {
+		err := utils.ReplaceInFile(
+			filepath.Join(projectDir, manifest),
+			"client_id: PLEASE_FILL_IN", fmt.Sprintf("client_id: %s", falconClientID))
+		ExpectWithOffset(1, err).NotTo(HaveOccurred())
+		err = utils.ReplaceInFile(filepath.Join(projectDir, manifest),
+			"client_secret: PLEASE_FILL_IN", fmt.Sprintf("client_secret: %s", falconClientSecret))
+		ExpectWithOffset(1, err).NotTo(HaveOccurred())
+	}
+}
+
+func addFalconSecretToManifest(manifest string) {
+	falconClientID, falconClientSecret := getCredentials()
+
+	By("creating a k8s secret with Falcon API credentials")
+	if falconClientID != "" && falconClientSecret != "" {
+		// Create secret namespace and secret
+		createNamespaceCmd := exec.Command("kubectl", "create", "ns", falconSecretNamespace)
+		_, err := utils.Run(createNamespaceCmd)
+		ExpectWithOffset(2, err).NotTo(HaveOccurred())
+
+		createSecretCmd := exec.Command("sh", "-c",
+			fmt.Sprintf("kubectl create secret generic %s -n %s --from-literal=falcon-client-id=\"$FALCON_CLIENT_ID\" --from-literal=falcon-client-secret=\"$FALCON_CLIENT_SECRET\"",
+				falconSecretName, falconSecretNamespace))
+		_, err = utils.Run(createSecretCmd)
+		ExpectWithOffset(2, err).NotTo(HaveOccurred())
+
+		err = utils.ReplaceInFile(filepath.Join(projectDir, manifest),
+			"namespace: PLEASE_FILL_IN", fmt.Sprintf("namespace: %s", falconSecretNamespace))
+		ExpectWithOffset(1, err).NotTo(HaveOccurred())
+		err = utils.ReplaceInFile(filepath.Join(projectDir, manifest),
+			"secretName: PLEASE_FILL_IN", fmt.Sprintf("secretName: %s", falconSecretName))
+		ExpectWithOffset(1, err).NotTo(HaveOccurred())
+	}
+}


### PR DESCRIPTION
Refactoring for readability and so that the e2e tests stop failing when the falcon-system namespace fails to delete in a timely manner. 