### PR TITLE
Add env variable for POD_NODE_NAME to daemonset container

### DIFF
--- a/internal/controller/assets/daemonset.go
+++ b/internal/controller/assets/daemonset.go
@@ -309,6 +309,16 @@ func Daemonset(dsName, image, serviceAccount string, node *falconv1alpha1.Falcon
 							Name:            "falcon-node-sensor",
 							Image:           image,
 							ImagePullPolicy: node.Spec.Node.ImagePullPolicy,
+							Env: []corev1.EnvVar{
+								{
+									Name: "POD_NODE_NAME",
+									ValueFrom: &corev1.EnvVarSource{
+										FieldRef: &corev1.ObjectFieldSelector{
+											FieldPath: "spec.nodeName",
+										},
+									},
+								},
+							},
 							EnvFrom: []corev1.EnvFromSource{
 								{
 									ConfigMapRef: &corev1.ConfigMapEnvSource{

--- a/internal/controller/assets/daemonset_test.go
+++ b/internal/controller/assets/daemonset_test.go
@@ -360,6 +360,16 @@ func TestDaemonset(t *testing.T) {
 							Name:            "falcon-node-sensor",
 							Image:           image,
 							ImagePullPolicy: falconNode.Spec.Node.ImagePullPolicy,
+							Env: []corev1.EnvVar{
+								{
+									Name: "POD_NODE_NAME",
+									ValueFrom: &corev1.EnvVarSource{
+										FieldRef: &corev1.ObjectFieldSelector{
+											FieldPath: "spec.nodeName",
+										},
+									},
+								},
+							},
 							EnvFrom: []corev1.EnvFromSource{
 								{
 									ConfigMapRef: &corev1.ConfigMapEnvSource{


### PR DESCRIPTION
The env variable is populated from spec.nodeName in the falcon-node-sensor container.